### PR TITLE
Remove annoying clang format options

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,7 +4,7 @@ SpaceBeforeParens: ControlStatements
 
 AccessModifierOffset: -4
 AlignAfterOpenBracket: Align
-AlignConsecutiveAssignments: true
+AlignConsecutiveAssignments: false
 AlignConsecutiveDeclarations: false
 AlignEscapedNewlines: Right
 AlignOperands:   true

--- a/plugin/hdCycles/attributeSource.cpp
+++ b/plugin/hdCycles/attributeSource.cpp
@@ -164,7 +164,7 @@ bool
 HdCyclesAttributeSource::IsHoldingFloat(const VtValue& value)
 {
     HdTupleType value_tuple_type = HdGetValueTupleType(value);
-    HdType component_type        = HdGetComponentType(value_tuple_type.type);
+    HdType component_type = HdGetComponentType(value_tuple_type.type);
     return component_type == HdTypeFloat;
 }
 
@@ -228,7 +228,7 @@ HdCyclesAttributeSource::_CheckValid() const
         }
     };
 
-    const size_t source_size  = get_source_size();
+    const size_t source_size = get_source_size();
     const size_t element_size = GetGeometry()->element_size(element, m_attributes->prim);
     if (!TF_VERIFY(source_size == element_size,
                    "SourceSize:%lu is not the same as ElementSize:%lu ! Attribute:%s can not be committed!",
@@ -258,7 +258,7 @@ HdCyclesAttributeSource::UncheckedCastToFloat(const VtValue& input_value)
     VtValue value = input_value;
 
     HdTupleType tuple_type = HdGetValueTupleType(value);
-    size_t count           = HdGetComponentCount(tuple_type.type);
+    size_t count = HdGetComponentCount(tuple_type.type);
 
     // Casting Matrix3 and Matrix4 is disabled.
     if (value.IsArrayValued()) {
@@ -295,8 +295,8 @@ HdCyclesAttributeSource::ResolveAsValue()
     // create attribute
     const ccl::ustring name { m_name.data(), m_name.size() };
     const ccl::AttributeElement& attrib_element = GetAttributeElement();
-    const ccl::TypeDesc& type_desc              = GetSourceTypeDesc();
-    m_attribute                                 = m_attributes->add(name, type_desc, attrib_element);
+    const ccl::TypeDesc& type_desc = GetSourceTypeDesc();
+    m_attribute = m_attributes->add(name, type_desc, attrib_element);
 
     // copy the data, source's stride is always <= than cycles'
     size_t num_src_comp = HdGetComponentCount(HdGetValueTupleType(m_value).type);
@@ -328,17 +328,17 @@ HdCyclesAttributeSource::ResolveAsArray()
     // create attribute
     const ccl::ustring name { m_name.data(), m_name.size() };
     const ccl::AttributeElement& attrib_element = GetAttributeElement();
-    const ccl::TypeDesc& type_desc              = GetSourceTypeDesc();
-    m_attribute                                 = m_attributes->add(name, type_desc, attrib_element);
+    const ccl::TypeDesc& type_desc = GetSourceTypeDesc();
+    m_attribute = m_attributes->add(name, type_desc, attrib_element);
 
     // copy the data, source's stride is always <= than cycles'
     size_t num_src_comp = HdGetComponentCount(HdGetValueTupleType(m_value).type);
-    size_t src_size     = m_value.GetArraySize() * num_src_comp;
-    auto src_data       = reinterpret_cast<const float*>(HdGetValueData(m_value));
+    size_t src_size = m_value.GetArraySize() * num_src_comp;
+    auto src_data = reinterpret_cast<const float*>(HdGetValueData(m_value));
     assert(src_data != nullptr);
 
     size_t num_dst_comp = GetTupleType(type_desc).count;
-    auto dst_data       = reinterpret_cast<float*>(m_attribute->data());
+    auto dst_data = reinterpret_cast<float*>(m_attribute->data());
     assert(dst_data != nullptr);
 
     assert(num_src_comp <= num_dst_comp);

--- a/plugin/hdCycles/basisCurves.cpp
+++ b/plugin/hdCycles/basisCurves.cpp
@@ -179,7 +179,7 @@ HdCyclesBasisCurves::_AddColors(TfToken name, VtValue value, HdInterpolation int
 {
     ccl::ustring attribName = ccl::ustring(name.GetString());
 
-    int vecSize      = 0;
+    int vecSize = 0;
     size_t numColors = 0;
 
     VtFloatArray colors1f;
@@ -188,20 +188,20 @@ HdCyclesBasisCurves::_AddColors(TfToken name, VtValue value, HdInterpolation int
     VtVec4fArray colors4f;
 
     if (value.IsHolding<VtArray<GfVec3f>>()) {
-        colors3f  = value.UncheckedGet<VtArray<GfVec3f>>();
-        vecSize   = 3;
+        colors3f = value.UncheckedGet<VtArray<GfVec3f>>();
+        vecSize = 3;
         numColors = colors3f.size();
     } else if (value.IsHolding<VtArray<GfVec4f>>()) {
-        colors4f  = value.UncheckedGet<VtArray<GfVec4f>>();
-        vecSize   = 4;
+        colors4f = value.UncheckedGet<VtArray<GfVec4f>>();
+        vecSize = 4;
         numColors = colors4f.size();
     } else if (value.IsHolding<VtArray<GfVec2f>>()) {
-        colors2f  = value.UncheckedGet<VtArray<GfVec2f>>();
-        vecSize   = 2;
+        colors2f = value.UncheckedGet<VtArray<GfVec2f>>();
+        vecSize = 2;
         numColors = colors2f.size();
     } else if (value.IsHolding<VtArray<float>>()) {
-        colors1f  = value.UncheckedGet<VtArray<float>>();
-        vecSize   = 1;
+        colors1f = value.UncheckedGet<VtArray<float>>();
+        vecSize = 1;
         numColors = colors1f.size();
     }
 
@@ -285,7 +285,7 @@ HdCyclesBasisCurves::_AddUVS(TfToken name, VtValue value, HdInterpolation interp
 
     auto fill_uniform_uv_attrib = [&attribName](auto& attr_uvs, ccl::AttributeSet& attributes) {
         ccl::Attribute* attr_std_uv = attributes.add(ccl::ATTR_STD_UV, attribName);
-        ccl::float2* std_uv_data    = attr_std_uv->data_float2();
+        ccl::float2* std_uv_data = attr_std_uv->data_float2();
 
         for (size_t curve = 0; curve < attr_uvs.size(); curve++) {
             std_uv_data[curve][0] = attr_uvs[curve][0];
@@ -321,10 +321,10 @@ HdCyclesBasisCurves::_AddUVS(TfToken name, VtValue value, HdInterpolation interp
     auto fill_vertex_or_varying_uv_attrib = [&attribName](auto& attr_uvs, ccl::AttributeSet& attributes,
                                                           const VtIntArray& vertexCounts) {
         ccl::Attribute* attr_std_uv = attributes.add(ccl::ATTR_STD_UV, attribName);
-        ccl::float2* std_uv_data    = attr_std_uv->data_float2();
+        ccl::float2* std_uv_data = attr_std_uv->data_float2();
 
         ccl::Attribute* attr_st = attributes.add(attribName, ccl::TypeFloat2, ccl::ATTR_ELEMENT_CURVE_KEY);
-        ccl::float2* st_data    = attr_st->data_float2();
+        ccl::float2* st_data = attr_st->data_float2();
 
         for (size_t curve = 0, offset = 0; curve < vertexCounts.size(); ++curve) {
             // std_uv - per curve
@@ -377,18 +377,18 @@ HdCyclesBasisCurves::_PopulateGenerated()
     if (m_cyclesMesh) {
         HdCyclesMeshTextureSpace(m_cyclesMesh, loc, size);
         ccl::Attribute* attr_generated = m_cyclesMesh->attributes.add(ccl::ATTR_STD_GENERATED);
-        ccl::float3* generated         = attr_generated->data_float3();
+        ccl::float3* generated = attr_generated->data_float3();
 
         for (size_t i = 0; i < m_cyclesMesh->verts.size(); i++)
             generated[i] = m_cyclesMesh->verts[i] * size - loc;
     } else {
         HdCyclesMeshTextureSpace(m_cyclesHair, loc, size);
         ccl::Attribute* attr_generated = m_cyclesHair->attributes.add(ccl::ATTR_STD_GENERATED);
-        ccl::float3* generated         = attr_generated->data_float3();
+        ccl::float3* generated = attr_generated->data_float3();
 
         for (size_t i = 0; i < m_cyclesHair->num_curves(); i++) {
             ccl::float3 co = m_cyclesHair->curve_keys[m_cyclesHair->get_curve(i).first_key];
-            generated[i]   = co * size - loc;
+            generated[i] = co * size - loc;
         }
     }
 }
@@ -414,19 +414,19 @@ HdCyclesBasisCurves::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderP
 
     HdCyclesPDPIMap pdpi;
     bool generate_new_curve = false;
-    bool update_curve       = false;
+    bool update_curve = false;
 
     // Defaults
     m_visCamera = m_visDiffuse = m_visGlossy = m_visScatter = m_visShadow = m_visTransmission = true;
-    m_useMotionBlur                                                                           = false;
-    m_cyclesObject->is_shadow_catcher                                                         = false;
-    m_cyclesObject->pass_id                                                                   = 0;
-    m_cyclesObject->use_holdout                                                               = false;
+    m_useMotionBlur = false;
+    m_cyclesObject->is_shadow_catcher = false;
+    m_cyclesObject->pass_id = 0;
+    m_cyclesObject->use_holdout = false;
 
     if (*dirtyBits & HdChangeTracker::DirtyPoints) {
         HdCyclesPopulatePrimvarDescsPerInterpolation(sceneDelegate, id, &pdpi);
         if (HdCyclesIsPrimvarExists(HdTokens->points, pdpi)) {
-            m_points           = sceneDelegate->Get(id, HdTokens->points).Get<VtVec3fArray>();
+            m_points = sceneDelegate->Get(id, HdTokens->points).Get<VtVec3fArray>();
             generate_new_curve = true;
 
             sceneDelegate->SamplePrimvar(id, HdTokens->points, &m_pointSamples);
@@ -438,7 +438,7 @@ HdCyclesBasisCurves::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderP
     if (*dirtyBits & HdChangeTracker::DirtyNormals) {
         HdCyclesPopulatePrimvarDescsPerInterpolation(sceneDelegate, id, &pdpi);
         if (HdCyclesIsPrimvarExists(HdTokens->normals, pdpi)) {
-            m_normals          = sceneDelegate->Get(id, HdTokens->normals).Get<VtVec3fArray>();
+            m_normals = sceneDelegate->Get(id, HdTokens->normals).Get<VtVec3fArray>();
             generate_new_curve = true;
         } else {
             m_normals = VtVec3fArray();
@@ -447,7 +447,7 @@ HdCyclesBasisCurves::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderP
 
     if (*dirtyBits & HdChangeTracker::DirtyTopology) {
         m_topology = sceneDelegate->GetBasisCurvesTopology(id);
-        m_indices  = VtIntArray();
+        m_indices = VtIntArray();
         if (m_topology.HasIndices()) {
             m_indices = m_topology.GetCurveIndices();
         }
@@ -460,7 +460,7 @@ HdCyclesBasisCurves::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderP
             // Even when no widths are authored, Hydra gives us a VtFloatArray with a constant width of 1
             m_widths = sceneDelegate->Get(id, HdTokens->widths).Get<VtFloatArray>();
         } else {
-            m_widths              = VtFloatArray(1, 0.1f);
+            m_widths = VtFloatArray(1, 0.1f);
             m_widthsInterpolation = HdInterpolationConstant;
             TF_WARN("[%s] Curve do not have widths. Fallback value is 1.0f with a constant interpolation",
                     id.GetText());
@@ -553,7 +553,7 @@ HdCyclesBasisCurves::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderP
     }
 
     if (*dirtyBits & HdChangeTracker::DirtyVisibility) {
-        update_curve        = true;
+        update_curve = true;
         _sharedData.visible = sceneDelegate->GetVisible(id);
     }
 
@@ -635,7 +635,7 @@ HdCyclesBasisCurves::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderP
 
         if (m_cyclesGeometry) {
             // Add default shader
-            const SdfPath& materialId        = sceneDelegate->GetMaterialId(GetId());
+            const SdfPath& materialId = sceneDelegate->GetMaterialId(GetId());
             const HdCyclesMaterial* material = static_cast<const HdCyclesMaterial*>(
                 sceneDelegate->GetRenderIndex().GetSprim(HdPrimTypeTokens->material, materialId));
 
@@ -648,7 +648,7 @@ HdCyclesBasisCurves::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderP
             }
 
             m_cyclesGeometry->used_shaders = m_usedShaders;
-            update_curve                   = true;
+            update_curve = true;
         }
     }
 
@@ -670,24 +670,24 @@ HdCyclesBasisCurves::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderP
 void
 HdCyclesBasisCurves::_CreateCurves(ccl::Scene* a_scene)
 {
-    m_cyclesHair     = new ccl::Hair();
+    m_cyclesHair = new ccl::Hair();
     m_cyclesGeometry = m_cyclesHair;
 
     // Get USD Curve Metadata
     VtIntArray curveVertexCounts = m_topology.GetCurveVertexCounts();
-    TfToken curveType            = m_topology.GetCurveType();
-    TfToken curveBasis           = m_topology.GetCurveBasis();
-    TfToken curveWrap            = m_topology.GetCurveWrap();
+    TfToken curveType = m_topology.GetCurveType();
+    TfToken curveBasis = m_topology.GetCurveBasis();
+    TfToken curveWrap = m_topology.GetCurveWrap();
 
     size_t num_curves = curveVertexCounts.size();
-    size_t num_keys   = 0;
+    size_t num_keys = 0;
 
     for (size_t i = 0; i < num_curves; i++) {
         num_keys += static_cast<size_t>(curveVertexCounts[i]);
     }
 
     ccl::Attribute* attr_intercept = nullptr;
-    ccl::Attribute* attr_random    = nullptr;
+    ccl::Attribute* attr_random = nullptr;
 
     attr_intercept = m_cyclesHair->attributes.add(ccl::ATTR_STD_CURVE_INTERCEPT);
 
@@ -698,7 +698,7 @@ HdCyclesBasisCurves::_CreateCurves(ccl::Scene* a_scene)
     m_cyclesHair->reserve_curves(static_cast<int>(num_curves), static_cast<int>(num_keys));
 
     num_curves = 0;
-    num_keys   = 0;
+    num_keys = 0;
 
     int currentPointCount = 0;
 
@@ -764,7 +764,7 @@ HdCyclesBasisCurves::_CreateCurves(ccl::Scene* a_scene)
 void
 HdCyclesBasisCurves::_CreateRibbons(ccl::Camera* a_camera)
 {
-    m_cyclesMesh     = new ccl::Mesh();
+    m_cyclesMesh = new ccl::Mesh();
     m_cyclesGeometry = m_cyclesMesh;
 
     bool isCameraOriented = false;
@@ -773,14 +773,14 @@ HdCyclesBasisCurves::_CreateRibbons(ccl::Camera* a_camera)
     bool is_ortho = false;
     if (m_normals.size() <= 0) {
         if (a_camera != nullptr) {
-            isCameraOriented     = true;
+            isCameraOriented = true;
             ccl::Transform& ctfm = a_camera->matrix;
             if (a_camera->type == ccl::CAMERA_ORTHOGRAPHIC) {
                 RotCam = -ccl::make_float3(ctfm.x.z, ctfm.y.z, ctfm.z.z);
             } else {
-                ccl::Transform tfm  = m_cyclesObject->tfm;
+                ccl::Transform tfm = m_cyclesObject->tfm;
                 ccl::Transform itfm = ccl::transform_quick_inverse(tfm);
-                RotCam              = ccl::transform_point(&itfm, ccl::make_float3(ctfm.x.w, ctfm.y.w, ctfm.z.w));
+                RotCam = ccl::transform_point(&itfm, ccl::make_float3(ctfm.x.w, ctfm.y.w, ctfm.z.w));
             }
             is_ortho = a_camera->type == ccl::CAMERA_ORTHOGRAPHIC;
         }
@@ -788,12 +788,12 @@ HdCyclesBasisCurves::_CreateRibbons(ccl::Camera* a_camera)
 
     // Get USD Curve Metadata
     VtIntArray curveVertexCounts = m_topology.GetCurveVertexCounts();
-    TfToken curveType            = m_topology.GetCurveType();
-    TfToken curveBasis           = m_topology.GetCurveBasis();
-    TfToken curveWrap            = m_topology.GetCurveWrap();
+    TfToken curveType = m_topology.GetCurveType();
+    TfToken curveBasis = m_topology.GetCurveBasis();
+    TfToken curveWrap = m_topology.GetCurveWrap();
 
     int num_vertices = 0;
-    int num_tris     = 0;
+    int num_tris = 0;
     for (size_t i = 0; i < curveVertexCounts.size(); i++) {
         num_vertices += curveVertexCounts[i] * 2;
         num_tris += ((curveVertexCounts[i] - 1) * 2);
@@ -847,7 +847,7 @@ HdCyclesBasisCurves::_CreateRibbons(ccl::Camera* a_camera)
         // For every section
         for (int j = 0; j < curveVertexCounts[i]; j++) {
             int first_idx = (static_cast<int>(i) * curveVertexCounts[i]);
-            int idx       = j + (static_cast<int>(i) * curveVertexCounts[i]);
+            int idx = j + (static_cast<int>(i) * curveVertexCounts[i]);
 
             ickey_loc = vec3f_to_float3(m_points[idx]);
 
@@ -901,17 +901,17 @@ HdCyclesBasisCurves::_CreateRibbons(ccl::Camera* a_camera)
 void
 HdCyclesBasisCurves::_CreateTubeMesh()
 {
-    m_cyclesMesh     = new ccl::Mesh();
+    m_cyclesMesh = new ccl::Mesh();
     m_cyclesGeometry = m_cyclesMesh;
 
     // Get USD Curve Metadata
     VtIntArray curveVertexCounts = m_topology.GetCurveVertexCounts();
-    TfToken curveType            = m_topology.GetCurveType();
-    TfToken curveBasis           = m_topology.GetCurveBasis();
-    TfToken curveWrap            = m_topology.GetCurveWrap();
+    TfToken curveType = m_topology.GetCurveType();
+    TfToken curveBasis = m_topology.GetCurveBasis();
+    TfToken curveWrap = m_topology.GetCurveWrap();
 
     int num_vertices = 0;
-    int num_tris     = 0;
+    int num_tris = 0;
     for (size_t i = 0; i < curveVertexCounts.size(); i++) {
         num_vertices += curveVertexCounts[i] * m_curveResolution;
         num_tris += ((curveVertexCounts[i] - 1) * 2 * m_curveResolution);
@@ -936,7 +936,7 @@ HdCyclesBasisCurves::_CreateTubeMesh()
         // For every section
         for (int j = 0; j < curveVertexCounts[i]; j++) {
             int first_idx = (static_cast<int>(i) * curveVertexCounts[i]);
-            int idx       = j + (static_cast<int>(i) * curveVertexCounts[i]);
+            int idx = j + (static_cast<int>(i) * curveVertexCounts[i]);
 
             ccl::float3 xbasis = firstxbasis;
             ccl::float3 v1;
@@ -966,7 +966,7 @@ HdCyclesBasisCurves::_CreateTubeMesh()
         // For every section
         for (int j = 0; j < curveVertexCounts[i]; j++) {
             int first_idx = (static_cast<int>(i) * curveVertexCounts[i]);
-            int idx       = j + (static_cast<int>(i) * curveVertexCounts[i]);
+            int idx = j + (static_cast<int>(i) * curveVertexCounts[i]);
             ccl::float3 xbasis;
             ccl::float3 ybasis;
             ccl::float3 v1;
@@ -1008,7 +1008,7 @@ HdCyclesBasisCurves::_CreateTubeMesh()
             xbasis = ccl::cross(v1, v2);
 
             if (ccl::len_squared(xbasis) >= 0.05f * ccl::len_squared(v1) * ccl::len_squared(v2)) {
-                xbasis      = ccl::normalize(xbasis);
+                xbasis = ccl::normalize(xbasis);
                 firstxbasis = xbasis;
             } else {
                 xbasis = firstxbasis;

--- a/plugin/hdCycles/basisCurves.h
+++ b/plugin/hdCycles/basisCurves.h
@@ -23,8 +23,8 @@
 #include "api.h"
 
 #include "hdcycles.h"
-#include "renderDelegate.h"
 #include "objectSource.h"
+#include "renderDelegate.h"
 #include "utils.h"
 
 #include <util/util_transform.h>

--- a/plugin/hdCycles/camera.cpp
+++ b/plugin/hdCycles/camera.cpp
@@ -247,15 +247,15 @@ HdCyclesCamera::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam,
                     m_apertureSize = (m_focalLength * 1e-3f) / (2.0f * m_fStop);
             }
             // TODO: We will need custom usdCycles schema for these
-            m_apertureRatio  = 1.0f;
-            m_blades         = 0;
+            m_apertureRatio = 1.0f;
+            m_blades = 0;
             m_bladesRotation = 0.0f;
         } else {
-            m_apertureSize   = 0.0f;
-            m_blades         = 0;
+            m_apertureSize = 0.0f;
+            m_blades = 0;
             m_bladesRotation = 0.0f;
-            m_focusDistance  = 0.0f;
-            m_apertureRatio  = 1.0f;
+            m_focusDistance = 0.0f;
+            m_apertureRatio = 1.0f;
         }
 
         // Motion Position
@@ -406,23 +406,23 @@ bool
 HdCyclesCamera::ApplyCameraSettings(ccl::Camera* a_camera)
 {
     a_camera->matrix = mat4d_to_transform(m_transform);
-    a_camera->fov    = m_fov;
+    a_camera->fov = m_fov;
 
-    a_camera->aperturesize   = m_apertureSize;
-    a_camera->blades         = m_blades;
+    a_camera->aperturesize = m_apertureSize;
+    a_camera->blades = m_blades;
     a_camera->bladesrotation = m_bladesRotation;
-    a_camera->focaldistance  = m_focusDistance;
+    a_camera->focaldistance = m_focusDistance;
     a_camera->aperture_ratio = m_apertureRatio;
 
     a_camera->shutter_curve = m_shutterCurve;
 
     a_camera->offscreen_dicing_scale = m_offscreenDicingScale;
 
-    a_camera->fisheye_fov  = m_fisheyeFov;
+    a_camera->fisheye_fov = m_fisheyeFov;
     a_camera->fisheye_lens = m_fisheyeLens;
 
-    a_camera->latitude_min  = m_latMin;
-    a_camera->latitude_max  = m_latMin;
+    a_camera->latitude_min = m_latMin;
+    a_camera->latitude_max = m_latMin;
     a_camera->longitude_min = m_latMax;
     a_camera->longitude_max = m_longMax;
 
@@ -430,24 +430,24 @@ HdCyclesCamera::ApplyCameraSettings(ccl::Camera* a_camera)
 
     a_camera->interocular_distance = m_interocularDistance;
     a_camera->convergence_distance = m_convergenceDistance;
-    a_camera->use_pole_merge       = m_usePoleMerge;
+    a_camera->use_pole_merge = m_usePoleMerge;
 
     a_camera->pole_merge_angle_from = m_poleMergeAngleFrom;
-    a_camera->pole_merge_angle_to   = m_poleMergeAngleTo;
+    a_camera->pole_merge_angle_to = m_poleMergeAngleTo;
 
     a_camera->nearclip = m_clippingRange.GetMin();
-    a_camera->farclip  = m_clippingRange.GetMax();
+    a_camera->farclip = m_clippingRange.GetMax();
 
-    a_camera->fps             = m_fps;
-    a_camera->shuttertime     = m_shutterTime;
+    a_camera->fps = m_fps;
+    a_camera->shuttertime = m_shutterTime;
     a_camera->motion_position = ccl::MotionPosition::MOTION_POSITION_CENTER;
 
     a_camera->rolling_shutter_duration = m_rollingShutterTime;
 
     a_camera->rolling_shutter_type = static_cast<ccl::Camera::RollingShutterType>(m_rollingShutterType);
-    a_camera->panorama_type        = static_cast<ccl::PanoramaType>(m_panoramaType);
-    a_camera->motion_position      = static_cast<ccl::MotionPosition>(m_motionPosition);
-    a_camera->stereo_eye           = static_cast<ccl::Camera::StereoEye>(m_stereoEye);
+    a_camera->panorama_type = static_cast<ccl::PanoramaType>(m_panoramaType);
+    a_camera->motion_position = static_cast<ccl::MotionPosition>(m_motionPosition);
+    a_camera->stereo_eye = static_cast<ccl::Camera::StereoEye>(m_stereoEye);
 
     if (m_projectionType == UsdGeomTokens->orthographic) {
         a_camera->type = ccl::CameraType::CAMERA_ORTHOGRAPHIC;
@@ -595,19 +595,19 @@ HdCyclesCamera::SetTransform(const GfMatrix4d a_projectionMatrix)
     GfMatrix4d viewToWorldCorrectionMatrix(1.0);
 
     if (m_projectionType == UsdGeomTokens->orthographic) {
-        double left   = -(1 + a_projectionMatrix[3][0]) / a_projectionMatrix[0][0];
-        double right  = (1 - a_projectionMatrix[3][0]) / a_projectionMatrix[0][0];
+        double left = -(1 + a_projectionMatrix[3][0]) / a_projectionMatrix[0][0];
+        double right = (1 - a_projectionMatrix[3][0]) / a_projectionMatrix[0][0];
         double bottom = -(1 - a_projectionMatrix[3][1]) / a_projectionMatrix[1][1];
-        double top    = (1 + a_projectionMatrix[3][1]) / a_projectionMatrix[1][1];
-        double w      = (right - left) / 2;
-        double h      = (top - bottom) / 2;
+        double top = (1 + a_projectionMatrix[3][1]) / a_projectionMatrix[1][1];
+        double w = (right - left) / 2;
+        double h = (top - bottom) / 2;
         GfMatrix4d scaleMatrix;
         scaleMatrix.SetScale(GfVec3d(w, h, 1));
         viewToWorldCorrectionMatrix = scaleMatrix;
     }
 
     GfMatrix4d flipZ(1.0);
-    flipZ[2][2]                 = -1.0;
+    flipZ[2][2] = -1.0;
     viewToWorldCorrectionMatrix = flipZ * viewToWorldCorrectionMatrix;
 
     GfMatrix4d matrix = viewToWorldCorrectionMatrix * m_transformSamples.values.data()[0];

--- a/plugin/hdCycles/config.cpp
+++ b/plugin/hdCycles/config.cpp
@@ -27,36 +27,36 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 template<> HdCyclesEnvValue<bool>::HdCyclesEnvValue(const char* a_envName, bool a_default)
 {
-    envName     = std::string(a_envName);
-    value       = TfGetenvBool(envName, a_default);
+    envName = std::string(a_envName);
+    value = TfGetenvBool(envName, a_default);
     hasOverride = TfGetenv(envName) != "";
 }
 
 template<> HdCyclesEnvValue<int>::HdCyclesEnvValue(const char* a_envName, int a_default)
 {
-    envName     = std::string(a_envName);
-    value       = TfGetenvInt(envName, a_default);
+    envName = std::string(a_envName);
+    value = TfGetenvInt(envName, a_default);
     hasOverride = TfGetenv(envName) != "";
 }
 
 template<> HdCyclesEnvValue<double>::HdCyclesEnvValue(const char* a_envName, double a_default)
 {
-    envName     = std::string(a_envName);
-    value       = TfGetenvDouble(envName, a_default);
+    envName = std::string(a_envName);
+    value = TfGetenvDouble(envName, a_default);
     hasOverride = TfGetenv(envName) != "";
 }
 
 template<> HdCyclesEnvValue<float>::HdCyclesEnvValue(const char* a_envName, float a_default)
 {
-    envName     = std::string(a_envName);
-    value       = static_cast<float>(TfGetenvDouble(envName, static_cast<double>(a_default)));
+    envName = std::string(a_envName);
+    value = static_cast<float>(TfGetenvDouble(envName, static_cast<double>(a_default)));
     hasOverride = TfGetenv(envName) != "";
 }
 
 template<> HdCyclesEnvValue<std::string>::HdCyclesEnvValue(const char* a_envName, std::string a_default)
 {
-    envName     = std::string(a_envName);
-    value       = TfGetenv(envName, a_default);
+    envName = std::string(a_envName);
+    value = TfGetenv(envName, a_default);
     hasOverride = TfGetenv(envName) != "";
 }
 
@@ -86,47 +86,47 @@ HdCyclesConfig::HdCyclesConfig()
     // -- Cycles Settings
     use_tiled_rendering = TfGetEnvSetting(HD_CYCLES_USE_TILED_RENDERING);
 
-    cycles_enable_logging   = TfGetEnvSetting(CYCLES_ENABLE_LOGGING);
+    cycles_enable_logging = TfGetEnvSetting(CYCLES_ENABLE_LOGGING);
     cycles_logging_severity = TfGetEnvSetting(CYCLES_LOGGING_SEVERITY);
 
     cycles_shader_graph_dump_dir = TfGetEnvSetting(CYCLES_DUMP_SHADER_GRAPH_DIR);
 
     // -- HdCycles Settings
-    enable_logging  = TfGetEnvSetting(HD_CYCLES_ENABLE_LOGGING);
+    enable_logging = TfGetEnvSetting(HD_CYCLES_ENABLE_LOGGING);
     enable_progress = TfGetEnvSetting(HD_CYCLES_ENABLE_PROGRESS);
 
     up_axis = TfGetEnvSetting(HD_CYCLES_UP_AXIS);
 
-    enable_motion_blur      = HdCyclesEnvValue<bool>("HD_CYCLES_ENABLE_MOTION_BLUR", false);
-    motion_steps            = HdCyclesEnvValue<int>("HD_CYCLES_MOTION_STEPS", 3);
-    enable_subdivision      = HdCyclesEnvValue<bool>("HD_CYCLES_ENABLE_SUBDIVISION", false);
+    enable_motion_blur = HdCyclesEnvValue<bool>("HD_CYCLES_ENABLE_MOTION_BLUR", false);
+    motion_steps = HdCyclesEnvValue<int>("HD_CYCLES_MOTION_STEPS", 3);
+    enable_subdivision = HdCyclesEnvValue<bool>("HD_CYCLES_ENABLE_SUBDIVISION", false);
     subdivision_dicing_rate = HdCyclesEnvValue<float>("HD_CYCLES_SUBDIVISION_DICING_RATE", 1.0);
-    max_subdivision         = HdCyclesEnvValue<int>("HD_CYCLES_MAX_SUBDIVISION", 12);
-    enable_dof              = HdCyclesEnvValue<bool>("HD_CYCLES_ENABLE_DOF", true);
+    max_subdivision = HdCyclesEnvValue<int>("HD_CYCLES_MAX_SUBDIVISION", 12);
+    enable_dof = HdCyclesEnvValue<bool>("HD_CYCLES_ENABLE_DOF", true);
 
-    render_width   = HdCyclesEnvValue<int>("HD_CYCLES_RENDER_WIDTH", 1280);
-    render_height  = HdCyclesEnvValue<int>("HD_CYCLES_RENDER_HEIGHT", 720);
+    render_width = HdCyclesEnvValue<int>("HD_CYCLES_RENDER_WIDTH", 1280);
+    render_height = HdCyclesEnvValue<int>("HD_CYCLES_RENDER_HEIGHT", 720);
     use_old_curves = HdCyclesEnvValue<bool>("HD_CYCLES_USE_OLD_CURVES", false);
 
     enable_transparent_background = HdCyclesEnvValue<bool>("HD_CYCLES_USE_TRANSPARENT_BACKGROUND", false);
-    use_square_samples            = HdCyclesEnvValue<bool>("HD_CYCLES_USE_SQUARE_SAMPLES", false);
+    use_square_samples = HdCyclesEnvValue<bool>("HD_CYCLES_USE_SQUARE_SAMPLES", false);
 
     // -- Cycles Settings
-    enable_experimental   = HdCyclesEnvValue<bool>("HD_CYCLES_ENABLE_EXPERIMENTAL", false);
-    bvh_type              = HdCyclesEnvValue<std::string>("HD_CYCLES_BVH_TYPE", "DYNAMIC");
-    device_name           = HdCyclesEnvValue<std::string>("HD_CYCLES_DEVICE_NAME", "CPU");
-    shading_system        = HdCyclesEnvValue<std::string>("HD_CYCLES_SHADING_SYSTEM", "SVM");
+    enable_experimental = HdCyclesEnvValue<bool>("HD_CYCLES_ENABLE_EXPERIMENTAL", false);
+    bvh_type = HdCyclesEnvValue<std::string>("HD_CYCLES_BVH_TYPE", "DYNAMIC");
+    device_name = HdCyclesEnvValue<std::string>("HD_CYCLES_DEVICE_NAME", "CPU");
+    shading_system = HdCyclesEnvValue<std::string>("HD_CYCLES_SHADING_SYSTEM", "SVM");
     display_buffer_linear = HdCyclesEnvValue<bool>("HD_CYCLES_DISPLAY_BUFFER_LINEAR", true);
 
     max_samples = HdCyclesEnvValue<int>("HD_CYCLES_MAX_SAMPLES", 512);
 
-    pixel_size              = HdCyclesEnvValue<int>("HD_CYCLES_PIXEL_SIZE", 1);
-    tile_size_x             = HdCyclesEnvValue<int>("HD_CYCLES_TILE_SIZE_X", 64);
-    tile_size_y             = HdCyclesEnvValue<int>("HD_CYCLES_TILE_SIZE_Y", 64);
-    start_resolution        = HdCyclesEnvValue<int>("HD_CYCLES_START_RESOLUTION", 8);
+    pixel_size = HdCyclesEnvValue<int>("HD_CYCLES_PIXEL_SIZE", 1);
+    tile_size_x = HdCyclesEnvValue<int>("HD_CYCLES_TILE_SIZE_X", 64);
+    tile_size_y = HdCyclesEnvValue<int>("HD_CYCLES_TILE_SIZE_Y", 64);
+    start_resolution = HdCyclesEnvValue<int>("HD_CYCLES_START_RESOLUTION", 8);
     shutter_motion_position = HdCyclesEnvValue<int>("HD_CYCLES_SHUTTER_MOTION_POSITION", 1);
 
-    default_point_style      = HdCyclesEnvValue<int>("HD_CYCLES_DEFAULT_POINT_STYLE", 0);
+    default_point_style = HdCyclesEnvValue<int>("HD_CYCLES_DEFAULT_POINT_STYLE", 0);
     default_point_resolution = HdCyclesEnvValue<int>("HD_CYCLES_DEFAULT_POINT_RESOLUTION", 16);
 
 
@@ -140,13 +140,13 @@ HdCyclesConfig::HdCyclesConfig()
     // -- Integrator Settings
     integrator_method = HdCyclesEnvValue<std::string>("HD_CYCLES_INTEGRATOR_METHOD", "PATH");
 
-    diffuse_samples      = HdCyclesEnvValue<int>("HD_CYCLES_DIFFUSE_SAMPLES", 1);
-    glossy_samples       = HdCyclesEnvValue<int>("HD_CYCLES_GLOSSY_SAMPLES", 1);
+    diffuse_samples = HdCyclesEnvValue<int>("HD_CYCLES_DIFFUSE_SAMPLES", 1);
+    glossy_samples = HdCyclesEnvValue<int>("HD_CYCLES_GLOSSY_SAMPLES", 1);
     transmission_samples = HdCyclesEnvValue<int>("HD_CYCLES_TRANSMISSION_SAMPLES", 1);
-    ao_samples           = HdCyclesEnvValue<int>("HD_CYCLES_AO_SAMPLES", 1);
-    mesh_light_samples   = HdCyclesEnvValue<int>("HD_CYCLES_MESH_LIGHT_SAMPLES", 1);
-    subsurface_samples   = HdCyclesEnvValue<int>("HD_CYCLES_SUBSURFACE_SAMPLES", 1);
-    volume_samples       = HdCyclesEnvValue<int>("HD_CYCLES_VOLUME_SAMPLES", 1);
+    ao_samples = HdCyclesEnvValue<int>("HD_CYCLES_AO_SAMPLES", 1);
+    mesh_light_samples = HdCyclesEnvValue<int>("HD_CYCLES_MESH_LIGHT_SAMPLES", 1);
+    subsurface_samples = HdCyclesEnvValue<int>("HD_CYCLES_SUBSURFACE_SAMPLES", 1);
+    volume_samples = HdCyclesEnvValue<int>("HD_CYCLES_VOLUME_SAMPLES", 1);
     adaptive_min_samples = HdCyclesEnvValue<int>("HD_CYCLES_VOLUME_SAMPLES", 1);
 }
 

--- a/plugin/hdCycles/config.h
+++ b/plugin/hdCycles/config.h
@@ -355,9 +355,9 @@ private:
      * @return 
      */
     HdCyclesConfig();
-    ~HdCyclesConfig()                     = default;
+    ~HdCyclesConfig() = default;
     HdCyclesConfig(const HdCyclesConfig&) = delete;
-    HdCyclesConfig(HdCyclesConfig&&)      = delete;
+    HdCyclesConfig(HdCyclesConfig&&) = delete;
     HdCyclesConfig& operator=(const HdCyclesConfig&) = delete;
 
     friend class TfSingleton<HdCyclesConfig>;

--- a/plugin/hdCycles/hdcycles.h
+++ b/plugin/hdCycles/hdcycles.h
@@ -20,7 +20,7 @@
 #ifndef HD_CYCLES_H
 #define HD_CYCLES_H
 
-static constexpr int HD_CYCLES_MOTION_STEPS        = 3;
+static constexpr int HD_CYCLES_MOTION_STEPS = 3;
 static constexpr int HD_CYCLES_MAX_PRIMVAR_SAMPLES = 3;
 
 #endif  // HD_CYCLES_H

--- a/plugin/hdCycles/instancer.cpp
+++ b/plugin/hdCycles/instancer.cpp
@@ -45,7 +45,7 @@ HdCyclesInstancer::Sync()
     HF_MALLOC_TAG_FUNCTION();
 
     const SdfPath& instancerId = GetId();
-    auto& changeTracker        = GetDelegate()->GetRenderIndex().GetChangeTracker();
+    auto& changeTracker = GetDelegate()->GetRenderIndex().GetChangeTracker();
 
     // Use the double-checked locking pattern to check if this instancer's
     // primvars are dirty.
@@ -100,7 +100,7 @@ HdCyclesInstancer::ComputeTransforms(SdfPath const& prototypeId)
     Sync();
 
     GfMatrix4d instancerTransform = GetDelegate()->GetInstancerTransform(GetId());
-    VtIntArray instanceIndices    = GetDelegate()->GetInstanceIndices(GetId(), prototypeId);
+    VtIntArray instanceIndices = GetDelegate()->GetInstanceIndices(GetId(), prototypeId);
 
     VtMatrix4dArray transforms;
     transforms.reserve(instanceIndices.size());
@@ -190,7 +190,7 @@ ApplyTransform(float alpha, VtValue const& allTransformsValue0, VtValue const& a
     for (size_t i = 0; i < instanceIndices.size(); ++i) {
         auto transform = HdResampleNeighbors(alpha, allTransforms0[instanceIndices[i]],
                                              allTransforms1[instanceIndices[i]]);
-        transforms[i]  = Op {}(transform)*transforms[i];
+        transforms[i] = Op {}(transform)*transforms[i];
     }
 }
 
@@ -217,7 +217,8 @@ ApplyTransform(HdTimeSampleArray<VtValue, HD_CYCLES_MOTION_STEPS> const& samples
         return ApplyTransform<Op, T>(samples.values[0], instanceIndices, transforms);
     } else if (i == samples.count) {
         // time is after the last sample.
-        return ApplyTransform<Op, T>(samples.values[static_cast<size_type>(samples.count) - 1], instanceIndices, transforms);
+        return ApplyTransform<Op, T>(samples.values[static_cast<size_type>(samples.count) - 1], instanceIndices,
+                                     transforms);
     } else if (samples.times[i] == samples.times[i - 1]) {
         // Neighboring samples have identical parameter.
         // Arbitrarily choose a sample.
@@ -259,7 +260,7 @@ struct TransformOp {
 HdTimeSampleArray<VtMatrix4dArray, HD_CYCLES_MOTION_STEPS>
 HdCyclesInstancer::SampleInstanceTransforms(SdfPath const& prototypeId)
 {
-    HdSceneDelegate* delegate  = GetDelegate();
+    HdSceneDelegate* delegate = GetDelegate();
     const SdfPath& instancerId = GetId();
 
     VtIntArray instanceIndices = delegate->GetInstanceIndices(instancerId, prototypeId);
@@ -312,7 +313,7 @@ HdCyclesInstancer::SampleInstanceTransforms(SdfPath const& prototypeId)
         }
 
         auto& transforms = sa.values[i];
-        transforms       = VtMatrix4dArray(instanceIndices.size(), xf);
+        transforms = VtMatrix4dArray(instanceIndices.size(), xf);
 
         if (translates.count > 0 && translates.values[0].IsArrayValued()) {
             auto& type = translates.values[0].GetElementTypeid();
@@ -384,7 +385,7 @@ HdCyclesInstancer::SampleInstanceTransforms(SdfPath const& prototypeId)
         const float t = sa.times[i];
         // Resample transforms at the same time.
         VtMatrix4dArray curParentXf = parentXf.Resample(t);
-        VtMatrix4dArray curChildXf  = childXf.Resample(t);
+        VtMatrix4dArray curChildXf = childXf.Resample(t);
         // Multiply out each combination.
         VtMatrix4dArray& result = sa.values[i];
         result.resize(curParentXf.size() * curChildXf.size());

--- a/plugin/hdCycles/light.cpp
+++ b/plugin/hdCycles/light.cpp
@@ -77,7 +77,7 @@ void
 HdCyclesLight::_CreateCyclesLight(SdfPath const& id, HdCyclesRenderParam* renderParam)
 {
     ccl::Scene* scene = renderParam->GetCyclesScene();
-    m_cyclesLight     = new ccl::Light();
+    m_cyclesLight = new ccl::Light();
 
     m_cyclesLight->name = ccl::ustring(id.GetName().c_str());
 
@@ -91,7 +91,7 @@ HdCyclesLight::_CreateCyclesLight(SdfPath const& id, HdCyclesRenderParam* render
         renderParam->SetBackgroundShader(shader);
     } else {
         if (m_hdLightType == HdPrimTypeTokens->diskLight) {
-            m_cyclesLight->type  = ccl::LIGHT_AREA;
+            m_cyclesLight->type = ccl::LIGHT_AREA;
             m_cyclesLight->round = true;
 
             m_cyclesLight->size = 1.0f;
@@ -100,7 +100,7 @@ HdCyclesLight::_CreateCyclesLight(SdfPath const& id, HdCyclesRenderParam* render
         } else if (m_hdLightType == HdPrimTypeTokens->distantLight) {
             m_cyclesLight->type = ccl::LIGHT_DISTANT;
         } else if (m_hdLightType == HdPrimTypeTokens->rectLight) {
-            m_cyclesLight->type  = ccl::LIGHT_AREA;
+            m_cyclesLight->type = ccl::LIGHT_AREA;
             m_cyclesLight->round = false;
 
             m_cyclesLight->size = 1.0f;
@@ -114,14 +114,14 @@ HdCyclesLight::_CreateCyclesLight(SdfPath const& id, HdCyclesRenderParam* render
     renderParam->AddShaderSafe(shader);
 
     // Set defaults
-    m_cyclesLight->use_diffuse      = true;
-    m_cyclesLight->use_glossy       = true;
+    m_cyclesLight->use_diffuse = true;
+    m_cyclesLight->use_glossy = true;
     m_cyclesLight->use_transmission = true;
-    m_cyclesLight->use_scatter      = true;
-    m_cyclesLight->cast_shadow      = true;
-    m_cyclesLight->use_mis          = true;
-    m_cyclesLight->is_portal        = false;
-    m_cyclesLight->max_bounces      = 1024;
+    m_cyclesLight->use_scatter = true;
+    m_cyclesLight->cast_shadow = true;
+    m_cyclesLight->use_mis = true;
+    m_cyclesLight->is_portal = false;
+    m_cyclesLight->max_bounces = 1024;
 
     m_cyclesLight->random_id = ccl::hash_uint2(ccl::hash_string(m_cyclesLight->name.c_str()), 0);
 
@@ -146,8 +146,8 @@ HdCyclesLight::_SetTransform(const ccl::Transform& a_transform)
         // Set the area light transforms
         m_cyclesLight->axisu = ccl::transform_get_column(&a_transform, 0);
         m_cyclesLight->axisv = ccl::transform_get_column(&a_transform, 1);
-        m_cyclesLight->co    = ccl::transform_get_column(&a_transform, 3);
-        m_cyclesLight->dir   = -ccl::transform_get_column(&a_transform, 2);
+        m_cyclesLight->co = ccl::transform_get_column(&a_transform, 3);
+        m_cyclesLight->dir = -ccl::transform_get_column(&a_transform, 2);
     }
 }
 
@@ -157,7 +157,7 @@ HdCyclesLight::_GetDefaultShaderGraph(bool isBackground)
     ccl::ShaderGraph* graph = new ccl::ShaderGraph();
     if (isBackground) {
         ccl::BackgroundNode* backgroundNode = new ccl::BackgroundNode();
-        backgroundNode->color               = ccl::make_float3(0.0f, 0.0f, 0.0f);
+        backgroundNode->color = ccl::make_float3(0.0f, 0.0f, 0.0f);
 
         backgroundNode->strength = 1.0f;
         graph->add(backgroundNode);
@@ -166,8 +166,8 @@ HdCyclesLight::_GetDefaultShaderGraph(bool isBackground)
         graph->connect(backgroundNode->output("Background"), out->input("Surface"));
     } else {
         ccl::EmissionNode* emissionNode = new ccl::EmissionNode();
-        emissionNode->color             = ccl::make_float3(1.0f, 1.0f, 1.0f);
-        emissionNode->strength          = 1.0f;
+        emissionNode->color = ccl::make_float3(1.0f, 1.0f, 1.0f);
+        emissionNode->strength = 1.0f;
         graph->add(emissionNode);
 
         ccl::ShaderNode* out = graph->output();
@@ -177,9 +177,7 @@ HdCyclesLight::_GetDefaultShaderGraph(bool isBackground)
 }
 
 ccl::ShaderNode*
-HdCyclesLight::_FindShaderNode(const ccl::ShaderGraph* graph, 
-                               const ccl::NodeType* type, 
-                               const ccl::ustring name)
+HdCyclesLight::_FindShaderNode(const ccl::ShaderGraph* graph, const ccl::NodeType* type, const ccl::ustring name)
 {
     for (ccl::ShaderNode* node : graph->nodes) {
         if ((node->type == type) && (node->name == name)) {
@@ -211,7 +209,7 @@ HdCyclesLight::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam, 
     m_cyclesLight->max_bounces = 1024;
 
     if (*dirtyBits & HdLight::DirtyParams) {
-        light_updated              = true;
+        light_updated = true;
         ccl::ShaderGraph* oldGraph = m_cyclesLight->shader->graph;
 
         // Check if we need to rebuild the graph
@@ -231,7 +229,7 @@ HdCyclesLight::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam, 
 
         VtValue textureFile = sceneDelegate->GetLightParamValue(id, HdLightTokens->textureFile);
         if (textureFile.IsHolding<SdfAssetPath>()) {
-            SdfAssetPath ap      = textureFile.UncheckedGet<SdfAssetPath>();
+            SdfAssetPath ap = textureFile.UncheckedGet<SdfAssetPath>();
             std::string filepath = ap.GetResolvedPath();
 
             if (filepath.length() > 0) {
@@ -239,15 +237,15 @@ HdCyclesLight::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam, 
             }
         }
 
-        ccl::ShaderGraph* graph  = nullptr;
+        ccl::ShaderGraph* graph = nullptr;
         ccl::ShaderNode* outNode = nullptr;
 
         // Ideally we would just check if it is different, however some nodes
         // simplify & fold internally so we have to re-create the graph, so if
         // there is any nodes used, re-create...
         if (shaderGraphBits || shaderGraphBits != m_shaderGraphBits) {
-            graph             = _GetDefaultShaderGraph(m_cyclesLight->type == ccl::LIGHT_BACKGROUND);
-            outNode           = graph->output()->input("Surface")->link->parent;
+            graph = _GetDefaultShaderGraph(m_cyclesLight->type == ccl::LIGHT_BACKGROUND);
+            outNode = graph->output()->input("Surface")->link->parent;
             m_shaderGraphBits = shaderGraphBits;
         } else {
             outNode = oldGraph->output()->input("Surface")->link->parent;
@@ -258,7 +256,7 @@ HdCyclesLight::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam, 
         // Color
         VtValue lightColor = sceneDelegate->GetLightParamValue(id, HdLightTokens->color);
         if (lightColor.IsHolding<GfVec3f>()) {
-            GfVec3f v               = lightColor.UncheckedGet<GfVec3f>();
+            GfVec3f v = lightColor.UncheckedGet<GfVec3f>();
             m_cyclesLight->strength = ccl::make_float3(v[0], v[1], v[2]);
         }
 
@@ -332,14 +330,14 @@ HdCyclesLight::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam, 
         // be used instead of ->filename, Blender uses it to store IES profiles in
         // .blend files...
         if (shaderGraphBits & ShaderGraphBits::IES) {
-            SdfAssetPath ap         = iesFile.UncheckedGet<SdfAssetPath>();
+            SdfAssetPath ap = iesFile.UncheckedGet<SdfAssetPath>();
             std::string iesfilepath = ap.GetResolvedPath();
 
             ccl::IESLightNode* iesNode = nullptr;
             if (graph) {
                 ccl::TextureCoordinateNode* iesTransform = new ccl::TextureCoordinateNode();
-                iesTransform->use_transform              = true;
-                iesTransform->ob_tfm                     = m_cyclesLight->tfm;
+                iesTransform->use_transform = true;
+                iesTransform->ob_tfm = m_cyclesLight->tfm;
                 graph->add(iesTransform);
 
                 iesNode = new ccl::IESLightNode();
@@ -374,7 +372,7 @@ HdCyclesLight::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam, 
             exposureOffset = 2.0f;
 
             if (shaderGraphBits & ShaderGraphBits::Texture) {
-                SdfAssetPath ap      = textureFile.UncheckedGet<SdfAssetPath>();
+                SdfAssetPath ap = textureFile.UncheckedGet<SdfAssetPath>();
                 std::string filepath = ap.GetResolvedPath();
 
                 ccl::ImageTextureNode* textureNode = nullptr;
@@ -388,7 +386,7 @@ HdCyclesLight::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam, 
 
                     if ((shaderGraphBits & ShaderGraphBits::Temperature) && blackbodyNode) {
                         ccl::VectorMathNode* vecMathNode = new ccl::VectorMathNode();
-                        vecMathNode->type                = ccl::NODE_VECTOR_MATH_MULTIPLY;
+                        vecMathNode->type = ccl::NODE_VECTOR_MATH_MULTIPLY;
                         graph->add(vecMathNode);
 
                         graph->connect(textureNode->output("Color"), vecMathNode->input("Vector1"));
@@ -459,13 +457,13 @@ HdCyclesLight::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam, 
             VtValue shapingConeAngle = sceneDelegate->GetLightParamValue(id, HdLightTokens->shapingConeAngle);
             if (shapingConeAngle.IsHolding<float>()) {
                 m_cyclesLight->spot_angle = shapingConeAngle.UncheckedGet<float>() * (M_PI_F / 180.0f) * 2.0f;
-                m_cyclesLight->type       = ccl::LIGHT_SPOT;
+                m_cyclesLight->type = ccl::LIGHT_SPOT;
             }
 
             VtValue shapingConeSoftness = sceneDelegate->GetLightParamValue(id, HdLightTokens->shapingConeSoftness);
             if (shapingConeSoftness.IsHolding<float>()) {
                 m_cyclesLight->spot_smooth = shapingConeSoftness.UncheckedGet<float>();
-                m_cyclesLight->type        = ccl::LIGHT_SPOT;
+                m_cyclesLight->type = ccl::LIGHT_SPOT;
             }
 
             if (m_cyclesLight->type == ccl::LIGHT_SPOT) {
@@ -486,11 +484,9 @@ HdCyclesLight::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam, 
         }
 
         if (m_hdLightType == HdPrimTypeTokens->domeLight) {
-
             ccl::BackgroundNode* backgroundNode = static_cast<ccl::BackgroundNode*>(outNode);
             ccl::VectorMathNode* strengthNode = nullptr;
-            if (shaderGraphBits & ShaderGraphBits::Texture ||
-                shaderGraphBits & ShaderGraphBits::Temperature) {
+            if (shaderGraphBits & ShaderGraphBits::Texture || shaderGraphBits & ShaderGraphBits::Temperature) {
                 if (graph) {
                     strengthNode = new ccl::VectorMathNode();
                     strengthNode->type = ccl::NODE_VECTOR_MATH_MULTIPLY;
@@ -514,15 +510,15 @@ HdCyclesLight::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam, 
             m_cyclesLight->strength = ccl::make_float3(1.0f, 1.0f, 1.0f);
 
             if (shaderGraphBits & ShaderGraphBits::Texture) {
-                SdfAssetPath ap      = textureFile.UncheckedGet<SdfAssetPath>();
+                SdfAssetPath ap = textureFile.UncheckedGet<SdfAssetPath>();
                 std::string filepath = ap.GetResolvedPath();
 
                 ccl::EnvironmentTextureNode* backgroundTexture = nullptr;
                 if (graph) {
                     // Add environment texture nodes
                     ccl::TextureCoordinateNode* backgroundTransform = new ccl::TextureCoordinateNode();
-                    backgroundTransform->use_transform              = true;
-                    backgroundTransform->ob_tfm                     = m_cyclesLight->tfm;
+                    backgroundTransform->use_transform = true;
+                    backgroundTransform->ob_tfm = m_cyclesLight->tfm;
                     graph->add(backgroundTransform);
 
                     backgroundTexture = new ccl::EnvironmentTextureNode();
@@ -530,8 +526,8 @@ HdCyclesLight::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam, 
                         // Change co-ordinate mapping on environment texture to match other Hydra delegates
                         backgroundTexture->tex_mapping.y_mapping = ccl::TextureMapping::Z;
                         backgroundTexture->tex_mapping.z_mapping = ccl::TextureMapping::Y;
-                        backgroundTexture->tex_mapping.scale     = ccl::make_float3(-1.0f, 1.0f, 1.0f);
-                        backgroundTexture->tex_mapping.rotation  = ccl::make_float3(0.0f, 0.0f, M_PI_F * -0.5f);
+                        backgroundTexture->tex_mapping.scale = ccl::make_float3(-1.0f, 1.0f, 1.0f);
+                        backgroundTexture->tex_mapping.rotation = ccl::make_float3(0.0f, 0.0f, M_PI_F * -0.5f);
                     }
 
                     graph->add(backgroundTexture);
@@ -597,7 +593,7 @@ HdCyclesLight::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam, 
 
     // TODO: Light is_enabled doesn't seem to have any effect
     if (*dirtyBits & HdChangeTracker::DirtyVisibility) {
-        light_updated             = true;
+        light_updated = true;
         m_cyclesLight->is_enabled = sceneDelegate->GetVisible(id);
     }
 

--- a/plugin/hdCycles/light.h
+++ b/plugin/hdCycles/light.h
@@ -106,11 +106,11 @@ private:
     // Tracking for Cycles light shader graphs, saves on potentially
     // expensive new/delete re-creation of graphs for interactive sessions.
     enum ShaderGraphBits : uint8_t {
-        Default     = 0,
+        Default = 0,
         Temperature = 1 << 0,
-        IES         = 1 << 1,
-        Texture     = 1 << 2,
-        All         = (Temperature | IES | Texture)
+        IES = 1 << 1,
+        Texture = 1 << 2,
+        All = (Temperature | IES | Texture)
     };
 
     /**
@@ -144,8 +144,7 @@ private:
      * @param type The type of ShaderNode to search for
      * @return The first ShaderNode found based on type in graph
      */
-    ccl::ShaderNode* _FindShaderNode(const ccl::ShaderGraph* graph, 
-                                     const ccl::NodeType* type, 
+    ccl::ShaderNode* _FindShaderNode(const ccl::ShaderGraph* graph, const ccl::NodeType* type,
                                      const ccl::ustring name = ccl::ustring());
 
     const TfToken m_hdLightType;

--- a/plugin/hdCycles/material.cpp
+++ b/plugin/hdCycles/material.cpp
@@ -127,7 +127,7 @@ ApplyPrimvarAOVs(ccl::ShaderGraph* graph)
             auto* attr = new ccl::AttributeNode();
             graph->add(attr);
             attr->attribute = ccl::ustring("Pref");
-            auto* aov       = new ccl::OutputAOVNode();
+            auto* aov = new ccl::OutputAOVNode();
             graph->add(aov);
             aov->name = ccl::ustring("Pref");
             graph->connect(attr->output("Vector"), aov->input("Color"));
@@ -155,9 +155,9 @@ HdCyclesMaterial::HdCyclesMaterial(SdfPath const& id, HdCyclesRenderDelegate* a_
     , m_shaderGraph(nullptr)
     , m_renderDelegate(a_renderDelegate)
 {
-    m_shader        = new ccl::Shader();
-    m_shader->name  = id.GetString();
-    m_shaderGraph   = new ccl::ShaderGraph();
+    m_shader = new ccl::Shader();
+    m_shader->name = id.GetString();
+    m_shaderGraph = new ccl::ShaderGraph();
     m_shader->graph = m_shaderGraph;
 
     if (m_renderDelegate)
@@ -179,7 +179,7 @@ ccl::ShaderNode*
 matConvertUSDPrimvarReader(HdMaterialNode& usd_node, ccl::ShaderGraph* cycles_shader_graph)
 {
     ccl::UVMapNode* uvmap = new ccl::UVMapNode();
-    uvmap->attribute      = ccl::ustring("st");
+    uvmap->attribute = ccl::ustring("st");
 
     for (std::pair<TfToken, VtValue> params : usd_node.parameters) {
         if (params.first == _tokens->varname) {
@@ -238,7 +238,7 @@ ccl::ShaderNode*
 matConvertUSDPreviewSurface(HdMaterialNode& usd_node, ccl::ShaderGraph* cycles_shader_graph)
 {
     ccl::PrincipledBsdfNode* principled = new ccl::PrincipledBsdfNode();
-    principled->base_color              = ccl::make_float3(1.0f, 1.0f, 1.0f);
+    principled->base_color = ccl::make_float3(1.0f, 1.0f, 1.0f);
 
     // Convert params
     for (std::pair<TfToken, VtValue> params : usd_node.parameters) {
@@ -385,12 +385,12 @@ convertCyclesNode(HdMaterialNode& usd_node, ccl::ShaderGraph* cycles_shader_grap
                 if (params.second.IsHolding<int>()) {
                     const ccl::NodeEnum& node_enums = *socket.enum_values;
                     auto index = params.second.Get<int>();
-                    if(node_enums.exists(index)) {
+                    if (node_enums.exists(index)) {
                         const char* value = node_enums[index].string().c_str();
                         cyclesNode->set(socket, value);
                     } else {
                         // fallback to Blender's defaults
-                        if(cycles_node_name == "principled_bsdf") {
+                        if (cycles_node_name == "principled_bsdf") {
                             cyclesNode->set(socket, "GGX");
                         } else {
                             TF_CODING_ERROR("Invalid enum without fallback value");
@@ -572,10 +572,10 @@ GetMaterialNetwork(TfToken const& terminal, HdSceneDelegate* delegate, HdMateria
 
         // Link material nodes
         for (const HdMaterialRelationship& matRel : net.second.relationships) {
-            ccl::ShaderNode* tonode   = conversionMap[matRel.outputId].second;
+            ccl::ShaderNode* tonode = conversionMap[matRel.outputId].second;
             ccl::ShaderNode* fromnode = conversionMap[matRel.inputId].second;
 
-            HdMaterialNode* hd_tonode   = conversionMap[matRel.outputId].first;
+            HdMaterialNode* hd_tonode = conversionMap[matRel.outputId].first;
             HdMaterialNode* hd_fromnode = conversionMap[matRel.inputId].first;
 
             // Skip invalid connections. I don't know where they come from, but they exist.
@@ -587,13 +587,13 @@ GetMaterialNetwork(TfToken const& terminal, HdSceneDelegate* delegate, HdMateria
                 continue;
             }
 
-            std::string to_identifier   = hd_tonode->identifier.GetString();
+            std::string to_identifier = hd_tonode->identifier.GetString();
             std::string from_identifier = hd_fromnode->identifier.GetString();
 
             ccl::ShaderOutput* output = NULL;
-            ccl::ShaderInput* input   = NULL;
+            ccl::ShaderInput* input = NULL;
 
-            bool to_has_valid_prefix   = IsValidCyclesIdentifier(to_identifier);
+            bool to_has_valid_prefix = IsValidCyclesIdentifier(to_identifier);
             bool from_has_valid_prefix = IsValidCyclesIdentifier(from_identifier);
 
             // Converts Preview surface connections
@@ -670,7 +670,7 @@ GetMaterialNetwork(TfToken const& terminal, HdSceneDelegate* delegate, HdMateria
 void
 HdCyclesMaterial::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam, HdDirtyBits* dirtyBits)
 {
-    auto cyclesRenderParam     = static_cast<HdCyclesRenderParam*>(renderParam);
+    auto cyclesRenderParam = static_cast<HdCyclesRenderParam*>(renderParam);
     HdCyclesRenderParam* param = static_cast<HdCyclesRenderParam*>(renderParam);
 
     const SdfPath& id = GetId();
@@ -688,9 +688,9 @@ HdCyclesMaterial::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderPara
 
             auto& networkMap = vtMat.UncheckedGet<HdMaterialNetworkMap>();
 
-            HdMaterialNetwork const* surface      = nullptr;
+            HdMaterialNetwork const* surface = nullptr;
             HdMaterialNetwork const* displacement = nullptr;
-            HdMaterialNetwork const* volume       = nullptr;
+            HdMaterialNetwork const* volume = nullptr;
 
             if (GetMaterialNetwork(HdCyclesMaterialTerminalTokens->surface, sceneDelegate, networkMap,
                                    *cyclesRenderParam, &surface, m_shaderGraph)) {

--- a/plugin/hdCycles/material.h
+++ b/plugin/hdCycles/material.h
@@ -96,10 +96,10 @@ public:
      * 
      */
     void Reload()
-    #if PXR_MAJOR_VERSION > 19
-    override
-    #endif
-    ;
+#if PXR_MAJOR_VERSION > 19
+        override
+#endif
+        ;
 
     /**
      * @return Return true if this material is valid

--- a/plugin/hdCycles/mesh.cpp
+++ b/plugin/hdCycles/mesh.cpp
@@ -105,7 +105,7 @@ HdCyclesMesh::_AddUVSet(const TfToken& name, const VtValue& uvs, ccl::Scene* sce
     }
 
     ccl::ustring uv_name = ccl::ustring(name.GetString());
-    bool need_uv         = m_cyclesMesh->need_attribute(scene, uv_name)
+    bool need_uv = m_cyclesMesh->need_attribute(scene, uv_name)
                    || m_cyclesMesh->need_attribute(scene, ccl::ATTR_STD_UV);
     if (!need_uv) {
         return;
@@ -116,8 +116,8 @@ HdCyclesMesh::_AddUVSet(const TfToken& name, const VtValue& uvs, ccl::Scene* sce
     // ATTR_STD_UV is a face varying data.
 
     ccl::AttributeSet* attributes = &m_cyclesMesh->attributes;
-    ccl::Attribute* uv_attr       = attributes->add(ccl::ATTR_STD_UV, uv_name);
-    auto attrib_data              = uv_attr->data_float2();
+    ccl::Attribute* uv_attr = attributes->add(ccl::ATTR_STD_UV, uv_name);
+    auto attrib_data = uv_attr->data_float2();
 
     if (interpolation == HdInterpolationConstant) {
         VtValue refined_value = m_refiner->RefineConstantData(name, HdPrimvarRoleTokens->textureCoordinate, uvs_value);
@@ -126,7 +126,7 @@ HdCyclesMesh::_AddUVSet(const TfToken& name, const VtValue& uvs, ccl::Scene* sce
             return;
         }
 
-        auto refined_uvs                    = refined_value.UncheckedGet<VtVec2fArray>();
+        auto refined_uvs = refined_value.UncheckedGet<VtVec2fArray>();
         const VtVec3iArray& refined_indices = m_refiner->GetRefinedVertexIndices();
         for (size_t face = 0, offset = 0; face < refined_indices.size(); ++face) {
             for (size_t i = 0; i < 3; ++i, ++offset) {
@@ -143,7 +143,7 @@ HdCyclesMesh::_AddUVSet(const TfToken& name, const VtValue& uvs, ccl::Scene* sce
             return;
         }
 
-        auto refined_uvs                    = refined_value.UncheckedGet<VtVec2fArray>();
+        auto refined_uvs = refined_value.UncheckedGet<VtVec2fArray>();
         const VtVec3iArray& refined_indices = m_refiner->GetRefinedVertexIndices();
         for (size_t face = 0, offset = 0; face < refined_indices.size(); ++face) {
             for (size_t i = 0; i < 3; ++i, ++offset) {
@@ -157,13 +157,13 @@ HdCyclesMesh::_AddUVSet(const TfToken& name, const VtValue& uvs, ccl::Scene* sce
     // convert vertex and varying
 
     auto add_vertex_or_varying_attrib = [&](const VtValue& refined_value) {
-        auto refined_uvs                    = refined_value.UncheckedGet<VtVec2fArray>();
+        auto refined_uvs = refined_value.UncheckedGet<VtVec2fArray>();
         const VtVec3iArray& refined_indices = m_refiner->GetRefinedVertexIndices();
         for (size_t face = 0, offset = 0; face < refined_indices.size(); ++face) {
             for (size_t i = 0; i < 3; ++i, ++offset) {
                 const int& vertex_index = refined_indices[face][i];
-                attrib_data[offset][0]  = refined_uvs[vertex_index][0];
-                attrib_data[offset][1]  = refined_uvs[vertex_index][1];
+                attrib_data[offset][0] = refined_uvs[vertex_index][0];
+                attrib_data[offset][1] = refined_uvs[vertex_index][1];
             }
         }
     };
@@ -218,8 +218,8 @@ HdCyclesMesh::_PopulateTangents(HdSceneDelegate* sceneDelegate, const SdfPath& i
 
     for (const ccl::ustring& name : m_texture_names) {
         ccl::ustring tangent_name = ccl::ustring(name.string() + ".tangent");
-        ccl::ustring sign_name    = ccl::ustring(name.string() + ".tangent_sign");
-        bool need_tangent         = false;
+        ccl::ustring sign_name = ccl::ustring(name.string() + ".tangent_sign");
+        bool need_tangent = false;
         need_tangent |= m_cyclesMesh->need_attribute(scene, tangent_name);
         need_tangent |= m_cyclesMesh->need_attribute(scene, ccl::ATTR_STD_UV_TANGENT);
 
@@ -233,17 +233,17 @@ HdCyclesMesh::_PopulateTangents(HdSceneDelegate* sceneDelegate, const SdfPath& i
 
             if (m_cyclesMesh->need_attribute(scene, ccl::ATTR_STD_UV_TANGENT)) {
                 ccl::Attribute* tangent_attrib = attributes->add(ccl::ATTR_STD_UV_TANGENT, tangent_name);
-                ccl::float3* tangent_data      = tangent_attrib->data_float3();
+                ccl::float3* tangent_data = tangent_attrib->data_float3();
 
                 for (size_t i = 0; i < m_cyclesMesh->triangles.size(); ++i) {
                     auto vertex_index = m_cyclesMesh->triangles[i];
-                    tangent_data[i]   = m_limit_us[vertex_index];
+                    tangent_data[i] = m_limit_us[vertex_index];
                 }
             }
 
             if (m_cyclesMesh->need_attribute(scene, ccl::ATTR_STD_UV_TANGENT_SIGN)) {
                 auto sign_attrib = attributes->add(ccl::ATTR_STD_UV_TANGENT_SIGN, sign_name);
-                auto sign_data   = sign_attrib->data_float();
+                auto sign_data = sign_attrib->data_float();
 
                 for (size_t i = 0; i < m_cyclesMesh->triangles.size(); ++i) {
                     sign_data[i] = 1.0f;
@@ -287,7 +287,7 @@ HdCyclesMesh::_AddVelocities(const SdfPath& id, const VtValue& value, HdInterpol
 
     // Turning on motion blur (todo: dynamic number of steps)
     m_cyclesMesh->use_motion_blur = true;
-    m_cyclesMesh->motion_steps    = 3;
+    m_cyclesMesh->motion_steps = 3;
 
     ccl::Attribute* attr_V = attributes->find(ccl::ATTR_STD_VERTEX_VELOCITY);
     if (!attr_V) {
@@ -397,7 +397,7 @@ HdCyclesMesh::_PopulateColors(const TfToken& name, const TfToken& role, const Vt
 
         ccl::ustring attrib_name { name.GetString().c_str(), name.GetString().size() };
         ccl::Attribute* color_attrib = attributes->add(attrib_name, ccl::TypeDesc::TypeColor, ccl::ATTR_ELEMENT_FACE);
-        ccl::float3* cycles_colors   = color_attrib->data_float3();
+        ccl::float3* cycles_colors = color_attrib->data_float3();
 
         auto refined_colors = refined_value.UncheckedGet<VtVec3fArray>();
         for (size_t i = 0; i < m_cyclesMesh->num_triangles(); ++i) {
@@ -418,7 +418,7 @@ HdCyclesMesh::_PopulateColors(const TfToken& name, const TfToken& role, const Vt
 
         ccl::ustring attrib_name { name.GetString().c_str(), name.GetString().size() };
         ccl::Attribute* color_attrib = attributes->add(attrib_name, ccl::TypeDesc::TypeColor, ccl::ATTR_ELEMENT_VERTEX);
-        ccl::float3* cycles_colors   = color_attrib->data_float3();
+        ccl::float3* cycles_colors = color_attrib->data_float3();
 
         auto refined_colors = refined_value.UncheckedGet<VtVec3fArray>();
         for (size_t i = 0; i < m_cyclesMesh->verts.size(); ++i) {
@@ -462,7 +462,7 @@ HdCyclesMesh::_PopulateColors(const TfToken& name, const TfToken& role, const Vt
 
         ccl::ustring attrib_name { name.GetString().c_str(), name.GetString().size() };
         ccl::Attribute* color_attrib = attributes->add(attrib_name, ccl::TypeDesc::TypeColor, ccl::ATTR_ELEMENT_CORNER);
-        ccl::float3* attrib_data     = color_attrib->data_float3();
+        ccl::float3* attrib_data = color_attrib->data_float3();
 
         auto refined_color = refined_value.UncheckedGet<VtVec3fArray>();
         for (size_t i = 0; i < refined_color.size(); ++i) {
@@ -505,8 +505,8 @@ HdCyclesMesh::_PopulateNormals(HdSceneDelegate* sceneDelegate, const SdfPath& id
         assert(m_limit_vs.size() == m_cyclesMesh->verts.size());
 
         ccl::AttributeSet& attributes = m_cyclesMesh->attributes;
-        ccl::Attribute* normal_attr   = attributes.add(ccl::ATTR_STD_VERTEX_NORMAL);
-        ccl::float3* normal_data      = normal_attr->data_float3();
+        ccl::Attribute* normal_attr = attributes.add(ccl::ATTR_STD_VERTEX_NORMAL);
+        ccl::float3* normal_data = normal_attr->data_float3();
 
         for (size_t i = 0; i < m_limit_vs.size(); ++i) {
             normal_data[i] = ccl::normalize(ccl::cross(m_limit_us[i], m_limit_vs[i]));
@@ -521,7 +521,7 @@ HdCyclesMesh::_PopulateNormals(HdSceneDelegate* sceneDelegate, const SdfPath& id
     auto GetPrimvarInterpolation = [sceneDelegate, &id](HdInterpolation& interpolation) -> bool {
         for (size_t i = 0; i < HdInterpolationCount; ++i) {
             HdPrimvarDescriptorVector d = sceneDelegate->GetPrimvarDescriptors(id, static_cast<HdInterpolation>(i));
-            auto predicate              = [](const HdPrimvarDescriptor& desc) -> bool {
+            auto predicate = [](const HdPrimvarDescriptor& desc) -> bool {
                 return desc.name == HdTokens->normals && desc.role == HdPrimvarRoleTokens->normal;
             };
             if (std::find_if(d.begin(), d.end(), predicate) != d.end()) {
@@ -560,7 +560,7 @@ HdCyclesMesh::_PopulateNormals(HdSceneDelegate* sceneDelegate, const SdfPath& id
 
     if (interpolation == HdInterpolationConstant) {
         ccl::Attribute* normal_attr = attributes.add(ccl::ATTR_STD_FACE_NORMAL);
-        ccl::float3* normal_data    = normal_attr->data_float3();
+        ccl::float3* normal_data = normal_attr->data_float3();
 
         const size_t num_triangles = m_refiner->GetNumRefinedTriangles();
         memset(normal_data, 0, num_triangles * sizeof(ccl::float3));
@@ -604,7 +604,7 @@ HdCyclesMesh::_PopulateNormals(HdSceneDelegate* sceneDelegate, const SdfPath& id
         }
 #else
         ccl::Attribute* normal_attr = attributes.add(ccl::ATTR_STD_CORNER_NORMAL);
-        ccl::float3* normal_data    = normal_attr->data_float3();
+        ccl::float3* normal_data = normal_attr->data_float3();
 
         const size_t num_triangles = m_refiner->GetNumRefinedTriangles();
         memset(normal_data, 0, num_triangles * sizeof(ccl::float3));
@@ -627,7 +627,7 @@ HdCyclesMesh::_PopulateNormals(HdSceneDelegate* sceneDelegate, const SdfPath& id
 #endif
     } else if (interpolation == HdInterpolationVertex || interpolation == HdInterpolationVarying) {
         ccl::Attribute* normal_attr = attributes.add(ccl::ATTR_STD_VERTEX_NORMAL);
-        ccl::float3* normal_data    = normal_attr->data_float3();
+        ccl::float3* normal_data = normal_attr->data_float3();
 
         const size_t num_vertices = m_refiner->GetNumRefinedVertices();
         memset(normal_data, 0, num_vertices * sizeof(ccl::float3));
@@ -650,7 +650,7 @@ HdCyclesMesh::_PopulateNormals(HdSceneDelegate* sceneDelegate, const SdfPath& id
         }
     } else if (interpolation == HdInterpolationFaceVarying) {
         ccl::Attribute* normal_attr = attributes.add(ccl::ATTR_STD_CORNER_NORMAL);
-        ccl::float3* normal_data    = normal_attr->data_float3();
+        ccl::float3* normal_data = normal_attr->data_float3();
 
         const size_t num_triangles = m_refiner->GetNumRefinedTriangles();
         memset(normal_data, 0, num_triangles * sizeof(ccl::float3));
@@ -690,7 +690,7 @@ HdCyclesMesh::_CreateCyclesObject()
 {
     ccl::Object* object = new ccl::Object();
 
-    object->tfm     = ccl::transform_identity();
+    object->tfm = ccl::transform_identity();
     object->pass_id = -1;
 
     object->visibility = ccl::PATH_RAY_ALL_VISIBILITY;
@@ -715,14 +715,14 @@ HdCyclesMesh::_PopulateMotion(HdSceneDelegate* sceneDelegate, const SdfPath& id)
     ccl::AttributeSet* attributes = &m_cyclesMesh->attributes;
 
     m_cyclesMesh->use_motion_blur = true;
-    m_cyclesMesh->motion_steps    = static_cast<unsigned int>(numSamples + ((numSamples % 2) ? 0 : 1));
+    m_cyclesMesh->motion_steps = static_cast<unsigned int>(numSamples + ((numSamples % 2) ? 0 : 1));
 
     ccl::Attribute* attr_mP = attributes->find(ccl::ATTR_STD_MOTION_VERTEX_POSITION);
 
     if (attr_mP)
         attributes->remove(attr_mP);
 
-    attr_mP         = attributes->add(ccl::ATTR_STD_MOTION_VERTEX_POSITION);
+    attr_mP = attributes->add(ccl::ATTR_STD_MOTION_VERTEX_POSITION);
     ccl::float3* mP = attr_mP->data_float3();
 
     for (size_t i = 0; i < numSamples; ++i) {
@@ -752,13 +752,13 @@ HdCyclesMesh::_PopulateTopology(HdSceneDelegate* sceneDelegate, const SdfPath& i
 
     HdDisplayStyle display_style = sceneDelegate->GetDisplayStyle(id);
 
-    auto refine_value         = GetPrimvar(sceneDelegate, usdCyclesTokens->primvarsCyclesMeshSubdivision_max_level);
-    int refine_level          = refine_value.IsEmpty() ? 0 : refine_value.Cast<int>().UncheckedGet<int>();
+    auto refine_value = GetPrimvar(sceneDelegate, usdCyclesTokens->primvarsCyclesMeshSubdivision_max_level);
+    int refine_level = refine_value.IsEmpty() ? 0 : refine_value.Cast<int>().UncheckedGet<int>();
     display_style.refineLevel = refine_level;
 
     // Refiner holds pointer to topology therefore refiner can't outlive the topology
     m_topology = HdMeshTopology(topology, display_style.refineLevel);
-    m_refiner  = HdCyclesMeshRefiner::Create(m_topology, id);
+    m_refiner = HdCyclesMeshRefiner::Create(m_topology, id);
 
     // Mesh is independently updated in two stages, faces(topology) and vertices(data).
     // Because process of updating vertices can fail for unknown reason,
@@ -818,7 +818,7 @@ HdCyclesMesh::_PopulateObjectMaterial(HdSceneDelegate* sceneDelegate, const SdfP
 
     // search for state primitive that contains cycles shader
     const HdSprim* material = render_index.GetSprim(HdPrimTypeTokens->material, material_id);
-    auto cycles_material    = dynamic_cast<const HdCyclesMaterial*>(material);
+    auto cycles_material = dynamic_cast<const HdCyclesMaterial*>(material);
     if (!cycles_material) {
         TF_WARN("Invalid HdCycles material %s", material_id.GetText());
         return;
@@ -853,7 +853,7 @@ HdCyclesMesh::_PopulateSubSetsMaterials(HdSceneDelegate* sceneDelegate, const Sd
 
         if (!subset.materialId.IsEmpty()) {
             const HdSprim* state_prim = render_index.GetSprim(HdPrimTypeTokens->material, subset.materialId);
-            auto sub_mat              = dynamic_cast<const HdCyclesMaterial*>(state_prim);
+            auto sub_mat = dynamic_cast<const HdCyclesMaterial*>(state_prim);
 
             if (!sub_mat)
                 continue;
@@ -864,7 +864,7 @@ HdCyclesMesh::_PopulateSubSetsMaterials(HdSceneDelegate* sceneDelegate, const Sd
             if (search_it == material_map.end()) {
                 used_shaders.push_back(sub_mat->GetCyclesShader());
                 material_map[subset.materialId] = static_cast<int>(used_shaders.size());
-                subset_material_id              = static_cast<int>(used_shaders.size());
+                subset_material_id = static_cast<int>(used_shaders.size());
             } else {
                 subset_material_id = search_it->second;
             }
@@ -930,7 +930,7 @@ HdCyclesMesh::_PopulatePrimvars(HdSceneDelegate* sceneDelegate, ccl::Scene* scen
             }
 
             auto interpolation = interpolation_description.first;
-            auto value         = GetPrimvar(sceneDelegate, description.name);
+            auto value = GetPrimvar(sceneDelegate, description.name);
 
             if (description.name == HdTokens->displayColor || description.role == HdPrimvarRoleTokens->color) {
                 _PopulateColors(description.name, description.role, value, scene, interpolation, id);
@@ -966,7 +966,7 @@ HdCyclesMesh::_PopulateVertices(HdSceneDelegate* sceneDelegate, const SdfPath& i
     //
     // Vertices from Usd Skel
     //
-    bool points_computed     = false;
+    bool points_computed = false;
     auto extComputationDescs = sceneDelegate->GetExtComputationPrimvarDescriptors(id, HdInterpolationVertex);
     for (auto& desc : extComputationDescs) {
         if (desc.name != HdTokens->points) {
@@ -974,11 +974,11 @@ HdCyclesMesh::_PopulateVertices(HdSceneDelegate* sceneDelegate, const SdfPath& i
         }
 
         if (HdChangeTracker::IsPrimvarDirty(*dirtyBits, id, desc.name)) {
-            auto valueStore   = HdExtComputationUtils::GetComputedPrimvarValues({ desc }, sceneDelegate);
+            auto valueStore = HdExtComputationUtils::GetComputedPrimvarValues({ desc }, sceneDelegate);
             auto pointValueIt = valueStore.find(desc.name);
             if (pointValueIt != valueStore.end()) {
                 if (!pointValueIt->second.IsEmpty()) {
-                    points_value    = pointValueIt->second;
+                    points_value = pointValueIt->second;
                     points_computed = true;
                 }
             }
@@ -1022,7 +1022,7 @@ HdCyclesMesh::_PopulateVertices(HdSceneDelegate* sceneDelegate, const SdfPath& i
     }
 
     for (size_t i = 0; i < points.size(); ++i) {
-        const GfVec3f& point   = points[i];
+        const GfVec3f& point = points[i];
         m_cyclesMesh->verts[i] = ccl::make_float3(point[0], point[1], point[2]);
     }
 
@@ -1054,7 +1054,7 @@ HdCyclesMesh::_PopulateGenerated(ccl::Scene* scene)
         HdCyclesMeshTextureSpace(m_cyclesMesh, loc, size);
 
         ccl::AttributeSet* attributes = &m_cyclesMesh->attributes;
-        ccl::Attribute* attr          = attributes->add(ccl::ATTR_STD_GENERATED);
+        ccl::Attribute* attr = attributes->add(ccl::ATTR_STD_GENERATED);
 
         ccl::float3* generated = attr->data_float3();
         for (size_t i = 0; i < m_cyclesMesh->verts.size(); i++) {
@@ -1085,8 +1085,8 @@ HdCyclesMesh::_InitializeNewCyclesMesh()
         delete m_cyclesObject;
     }
 
-    m_cyclesObject        = _CreateCyclesObject();
-    m_cyclesMesh          = _CreateCyclesMesh();
+    m_cyclesObject = _CreateCyclesObject();
+    m_cyclesMesh = _CreateCyclesMesh();
     m_numTransformSamples = HD_CYCLES_MOTION_STEPS;
 
     if (m_useMotionBlur) {
@@ -1100,11 +1100,11 @@ HdCyclesMesh::_InitializeNewCyclesMesh()
         m_useDeformMotionBlur = true;
 
         // TODO: Needed when we properly handle motion_verts
-        m_cyclesMesh->motion_steps    = m_motionSteps;
+        m_cyclesMesh->motion_steps = m_motionSteps;
         m_cyclesMesh->use_motion_blur = m_useDeformMotionBlur;
     }
 
-    m_cyclesObject->name     = GetId().GetString();
+    m_cyclesObject->name = GetId().GetString();
     m_cyclesObject->geometry = m_cyclesMesh;
 
     m_renderDelegate->GetCyclesRenderParam()->AddGeometrySafe(m_cyclesMesh);
@@ -1167,7 +1167,7 @@ void
 HdCyclesMesh::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam, HdDirtyBits* dirtyBits,
                    TfToken const& reprToken)
 {
-    auto param                    = dynamic_cast<HdCyclesRenderParam*>(renderParam);
+    auto param = dynamic_cast<HdCyclesRenderParam*>(renderParam);
     m_object_display_color_shader = param->default_object_display_color_surface;
     m_attrib_display_color_shader = param->default_attrib_display_color_surface;
 
@@ -1190,12 +1190,12 @@ HdCyclesMesh::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam, H
     // Set defaults, so that in a "do nothing" scenario it'll revert to defaults, or if you view
     // a different node context without any settings set.
     m_visCamera = m_visDiffuse = m_visGlossy = m_visScatter = m_visShadow = m_visTransmission = true;
-    m_useMotionBlur                                                                           = false;
-    m_useDeformMotionBlur                                                                     = false;
-    m_motionSteps                                                                             = 3;
-    m_cyclesObject->is_shadow_catcher                                                         = false;
-    m_cyclesObject->pass_id                                                                   = 0;
-    m_cyclesObject->use_holdout                                                               = false;
+    m_useMotionBlur = false;
+    m_useDeformMotionBlur = false;
+    m_motionSteps = 3;
+    m_cyclesObject->is_shadow_catcher = false;
+    m_cyclesObject->pass_id = 0;
+    m_cyclesObject->use_holdout = false;
 
     for (auto& primvarDescsEntry : primvarDescsPerInterpolation) {
         for (auto& pv : primvarDescsEntry.second) {
@@ -1326,8 +1326,7 @@ HdCyclesMesh::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam, H
     if (*dirtyBits & HdChangeTracker::DirtyInstancer) {
         const SdfPath& instancer_id = GetInstancerId();
         auto instancer = dynamic_cast<HdCyclesInstancer*>(sceneDelegate->GetRenderIndex().GetInstancer(instancer_id));
-        if (instancer){
-
+        if (instancer) {
             // Clear all instances...
             for (auto instance : m_cyclesInstances) {
                 if (instance) {
@@ -1339,7 +1338,7 @@ HdCyclesMesh::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam, H
 
             // create new instances
             auto instanceTransforms = instancer->SampleInstanceTransforms(id);
-            auto newNumInstances    = (instanceTransforms.count > 0) ? instanceTransforms.values[0].size() : 0;
+            auto newNumInstances = (instanceTransforms.count > 0) ? instanceTransforms.values[0].size() : 0;
 
             if (newNumInstances != 0) {
                 using size_type = typename decltype(m_transformSamples.values)::size_type;
@@ -1358,7 +1357,7 @@ HdCyclesMesh::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam, H
                         }
                     } else {
                         for (size_type j = 0; j < instanceTransforms.count; ++j) {
-                            GfMatrix4d xf_j      = m_transformSamples.Resample(instanceTransforms.times[j]);
+                            GfMatrix4d xf_j = m_transformSamples.Resample(instanceTransforms.times[j]);
                             instanceTransform[j] = xf_j * instanceTransforms.values[j][i];
                         }
                     }
@@ -1367,7 +1366,7 @@ HdCyclesMesh::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam, H
                 for (size_t j = 0; j < newNumInstances; ++j) {
                     ccl::Object* instanceObj = _CreateCyclesObject();
 
-                    instanceObj->tfm      = mat4d_to_transform(combinedTransforms[j].data()[0]);
+                    instanceObj->tfm = mat4d_to_transform(combinedTransforms[j].data()[0]);
                     instanceObj->geometry = m_cyclesMesh;
 
                     // TODO: Implement motion blur for point instanced objects

--- a/plugin/hdCycles/meshRefiner.cpp
+++ b/plugin/hdCycles/meshRefiner.cpp
@@ -192,13 +192,13 @@ public:
     explicit SubdUniformRefiner(const Far::TopologyRefiner& refiner, const Osd::CpuPatchTable* patch_table)
         : m_patch_table { patch_table }
     {
-        int face_size                        = Sdc::SchemeTypeTraits::GetRegularFaceSize(refiner.GetSchemeType());
+        int face_size = Sdc::SchemeTypeTraits::GetRegularFaceSize(refiner.GetSchemeType());
         const Far::TopologyLevel& base_level = refiner.GetLevel(0);
         m_ptex_index_to_base_index.reserve(base_level.GetNumFaces() * face_size);  // worst case
 
         for (int base_face = 0; base_face < base_level.GetNumFaces(); ++base_face) {
             int num_base_vertices = base_level.GetFaceVertices(base_face).size();
-            int num_ptex_faces    = (num_base_vertices == face_size) ? 1 : num_base_vertices;
+            int num_ptex_faces = (num_base_vertices == face_size) ? 1 : num_base_vertices;
             for (int i = 0; i < num_ptex_faces; ++i) {
                 m_ptex_index_to_base_index.push_back(base_face);
             }
@@ -243,7 +243,7 @@ private:
 
             // patch -> ptex face
             const Far::PatchParam& patch_param = patch_param_table[patch_index];
-            Far::Index ptex_face_index         = patch_param.GetFaceId();
+            Far::Index ptex_face_index = patch_param.GetFaceId();
             assert(static_cast<size_t>(ptex_face_index) < m_ptex_index_to_base_index.size());
 
             // ptex face -> base face
@@ -280,7 +280,7 @@ VtValue
 RefineWithStencils(const VtValue& input, const Far::StencilTable* stencil_table)
 {
     HdTupleType value_tuple_type = HdGetValueTupleType(input);
-    int stride                   = static_cast<int>(HdGetComponentCount(value_tuple_type.type));
+    int stride = static_cast<int>(HdGetComponentCount(value_tuple_type.type));
 
     switch (value_tuple_type.type) {
     case HdTypeFloat: {
@@ -307,8 +307,8 @@ public:
     SubdVertexRefiner(const Far::TopologyRefiner& refiner, Far::StencilTableFactory::Options options)
     {
         options.interpolationMode = Far::StencilTableFactory::INTERPOLATE_VERTEX;
-        auto table                = Far::StencilTableFactory::Create(refiner, options);
-        m_stencils                = std::unique_ptr<const Far::StencilTable>(table);
+        auto table = Far::StencilTableFactory::Create(refiner, options);
+        m_stencils = std::unique_ptr<const Far::StencilTable>(table);
     }
 
     VtValue RefineArray(const VtValue& input) const { return RefineWithStencils(input, m_stencils.get()); }
@@ -327,8 +327,8 @@ public:
     SubdVaryingRefiner(const Far::TopologyRefiner& refiner, Far::StencilTableFactory::Options options)
     {
         options.interpolationMode = Far::StencilTableFactory::INTERPOLATE_VARYING;
-        auto table                = Far::StencilTableFactory::Create(refiner, options);
-        m_stencils                = std::unique_ptr<const Far::StencilTable> { table };
+        auto table = Far::StencilTableFactory::Create(refiner, options);
+        m_stencils = std::unique_ptr<const Far::StencilTable> { table };
     }
 
     VtValue RefineArray(const VtValue& input) const { return RefineWithStencils(input, m_stencils.get()); }
@@ -347,14 +347,14 @@ public:
         : m_patch_table { patch_table }
     {
         options.interpolationMode = Far::StencilTableFactory::INTERPOLATE_FACE_VARYING;
-        auto table                = Far::StencilTableFactory::Create(refiner, options);
-        m_stencils                = std::unique_ptr<const Far::StencilTable>(table);
+        auto table = Far::StencilTableFactory::Create(refiner, options);
+        m_stencils = std::unique_ptr<const Far::StencilTable>(table);
     }
 
     VtValue RefineArray(const VtValue& input) const
     {
         HdTupleType value_tuple_type = HdGetValueTupleType(input);
-        auto stride                  = static_cast<int>(HdGetComponentCount(value_tuple_type.type));
+        auto stride = static_cast<int>(HdGetComponentCount(value_tuple_type.type));
 
         switch (value_tuple_type.type) {
         case HdTypeFloat: {
@@ -392,7 +392,7 @@ private:
         VtArray<T> eval_data(m_patch_table->GetPatchIndexSize());
         {
             for (size_t fvert = 0; fvert < m_patch_table->GetFVarPatchIndexSize(); ++fvert) {
-                int index        = m_patch_table->GetFVarPatchIndexBuffer()[fvert];
+                int index = m_patch_table->GetFVarPatchIndexBuffer()[fvert];
                 eval_data[fvert] = refined_data[index];
             }
         }
@@ -452,9 +452,9 @@ public:
                        VtFloat3Array& limit_dv) const
     {
         auto refined_ps_primvar = reinterpret_cast<const Float3fPrimvar*>(refined_vertices.data());
-        auto limit_ps_primvar   = reinterpret_cast<Float3fPrimvar*>(limit_ps.data());
-        auto limit_du_primvar   = reinterpret_cast<Float3fPrimvar*>(limit_du.data());
-        auto limit_dv_primvar   = reinterpret_cast<Float3fPrimvar*>(limit_dv.data());
+        auto limit_ps_primvar = reinterpret_cast<Float3fPrimvar*>(limit_ps.data());
+        auto limit_du_primvar = reinterpret_cast<Float3fPrimvar*>(limit_du.data());
+        auto limit_dv_primvar = reinterpret_cast<Float3fPrimvar*>(limit_dv.data());
 
         m_primvar_refiner.Limit(refined_ps_primvar, limit_ps_primvar, limit_du_primvar, limit_dv_primvar);
     }
@@ -505,12 +505,12 @@ public:
             // by default Far will not generate patches for all levels, triangulate quads option works for uniform subdivision only
             Far::PatchTableFactory::Options patch_options(m_topology->GetRefineLevel());
             patch_options.generateAllLevels = false;
-            patch_options.useInfSharpPatch  = true;
+            patch_options.useInfSharpPatch = true;
 
             // only if face varying is present
             patch_options.generateFVarTables = true;
-            patch_options.numFVarChannels    = m_refiner->GetNumFVarChannels();
-            int channel                      = 0;
+            patch_options.numFVarChannels = m_refiner->GetNumFVarChannels();
+            int channel = 0;
             patch_options.fvarChannelIndices = &channel;
 
             std::unique_ptr<Far::PatchTable> far_patch_table { Far::PatchTableFactory::Create(*m_refiner,
@@ -525,16 +525,16 @@ public:
             // Shared options for all stencils
             Far::StencilTableFactory::Options stencil_options;
             stencil_options.generateIntermediateLevels = false;
-            stencil_options.generateOffsets            = true;
+            stencil_options.generateOffsets = true;
 
             // required stencils for vertex and normal computation
-            m_vertex  = std::make_unique<SubdVertexRefiner>(*m_refiner, stencil_options);
+            m_vertex = std::make_unique<SubdVertexRefiner>(*m_refiner, stencil_options);
             m_uniform = std::make_unique<SubdUniformRefiner>(*m_refiner, m_patch_table.get());
 
             // optional refiners depending on presence of PrimVars
-            m_limit   = std::make_unique<SubdLimitRefiner>(*m_refiner);
+            m_limit = std::make_unique<SubdLimitRefiner>(*m_refiner);
             m_varying = std::make_unique<SubdVaryingRefiner>(*m_refiner, stencil_options);
-            m_fvar    = std::make_unique<SubdFVarRefiner>(*m_refiner, m_patch_table.get(), stencil_options);
+            m_fvar = std::make_unique<SubdFVarRefiner>(*m_refiner, m_patch_table.get(), stencil_options);
         }
 
         // create Osd topology

--- a/plugin/hdCycles/meshRefiner.h
+++ b/plugin/hdCycles/meshRefiner.h
@@ -54,16 +54,16 @@ public:
     virtual ~HdCyclesMeshRefiner();
 
     /// @{ TODO: Those methods belong to HdCyclesMeshTopology
-    virtual size_t GetNumRefinedVertices() const                = 0;
+    virtual size_t GetNumRefinedVertices() const = 0;
     virtual const VtVec3iArray& GetRefinedVertexIndices() const = 0;
     size_t GetNumRefinedTriangles() const;
     /// @}
 
     /// @{ \brief Refine/approximate primvar data.
-    virtual VtValue RefineConstantData(const TfToken& name, const TfToken& role, const VtValue& data) const    = 0;
-    virtual VtValue RefineUniformData(const TfToken& name, const TfToken& role, const VtValue& data) const     = 0;
-    virtual VtValue RefineVaryingData(const TfToken& name, const TfToken& role, const VtValue& data) const     = 0;
-    virtual VtValue RefineVertexData(const TfToken& name, const TfToken& role, const VtValue& data) const      = 0;
+    virtual VtValue RefineConstantData(const TfToken& name, const TfToken& role, const VtValue& data) const = 0;
+    virtual VtValue RefineUniformData(const TfToken& name, const TfToken& role, const VtValue& data) const = 0;
+    virtual VtValue RefineVaryingData(const TfToken& name, const TfToken& role, const VtValue& data) const = 0;
+    virtual VtValue RefineVertexData(const TfToken& name, const TfToken& role, const VtValue& data) const = 0;
     virtual VtValue RefineFaceVaryingData(const TfToken& name, const TfToken& role, const VtValue& data) const = 0;
     /// @}
 
@@ -72,7 +72,7 @@ public:
     virtual void EvaluateLimit(const VtFloat3Array& refined_vertices, VtFloat3Array& limit_ps, VtFloat3Array& limit_du,
                                VtFloat3Array& limit_dv) const = 0;
 
-    HdCyclesMeshRefiner(const HdCyclesMeshRefiner&)     = delete;
+    HdCyclesMeshRefiner(const HdCyclesMeshRefiner&) = delete;
     HdCyclesMeshRefiner(HdCyclesMeshRefiner&&) noexcept = delete;
 
     HdCyclesMeshRefiner& operator=(const HdCyclesMeshRefiner&) = delete;

--- a/plugin/hdCycles/objectSource.cpp
+++ b/plugin/hdCycles/objectSource.cpp
@@ -55,7 +55,7 @@ HdCyclesObjectSource::Resolve()
 void
 HdCyclesObjectSource::AddSource(HdBufferSourceSharedPtr source)
 {
-    const TfToken& name     = source->GetName();
+    const TfToken& name = source->GetName();
     m_pending_sources[name] = std::move(source);
 }
 

--- a/plugin/hdCycles/points.cpp
+++ b/plugin/hdCycles/points.cpp
@@ -103,7 +103,7 @@ HdCyclesPoints::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam,
 
     ccl::Scene* scene = param->GetCyclesScene();
 
-    bool needs_update  = false;
+    bool needs_update = false;
     bool needs_newMesh = true;
 
     // Read Cycles Primvars
@@ -115,7 +115,7 @@ HdCyclesPoints::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam,
         sceneDelegate->SamplePrimvar(id, usdCyclesTokens->cyclesObjectPoint_style, &xf);
         if (xf.count > 0) {
             const TfToken& styles = xf.values[0].Get<TfToken>();
-            m_pointStyle          = POINT_DISCS;
+            m_pointStyle = POINT_DISCS;
             if (styles == usdCyclesTokens->sphere) {
                 m_pointStyle = POINT_SPHERES;
             }
@@ -129,7 +129,7 @@ HdCyclesPoints::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam,
         sceneDelegate->SamplePrimvar(id, usdCyclesTokens->cyclesObjectPoint_resolution, &xf);
         if (xf.count > 0) {
             const int& resolutions = xf.values[0].Get<int>();
-            m_pointResolution      = std::max(resolutions, 10);
+            m_pointResolution = std::max(resolutions, 10);
         }
     }
 
@@ -163,7 +163,7 @@ HdCyclesPoints::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam,
                                                                m_cyclesMesh);
 
                 pointObject->random_id = static_cast<unsigned int>(i);
-                pointObject->name      = ccl::ustring::format("%s@%08x", pointObject->name, pointObject->random_id);
+                pointObject->name = ccl::ustring::format("%s@%08x", pointObject->name, pointObject->random_id);
                 m_cyclesObjects.push_back(pointObject);
                 param->AddObjectSafe(pointObject);
             }
@@ -194,7 +194,7 @@ HdCyclesPoints::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam,
                 const VtFloatArray& widths = xf.values[0].Get<VtFloatArray>();
                 for (size_t i = 0; i < widths.size(); i++) {
                     if (i < m_cyclesObjects.size()) {
-                        float w                 = widths[i];
+                        float w = widths[i];
                         m_cyclesObjects[i]->tfm = m_cyclesObjects[i]->tfm * ccl::transform_scale(w, w, w);
                     }
                 }
@@ -212,11 +212,11 @@ HdCyclesPoints::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam,
                 const VtVec3fArray& normals = xf.values[0].Get<VtVec3fArray>();
                 for (size_t i = 0; i < normals.size(); i++) {
                     if (i < m_cyclesObjects.size()) {
-                        ccl::float3 rotAxis     = ccl::cross(ccl::make_float3(0.0f, 0.0f, 1.0f),
+                        ccl::float3 rotAxis = ccl::cross(ccl::make_float3(0.0f, 0.0f, 1.0f),
                                                          ccl::make_float3(normals[i][0], normals[i][1], normals[i][2]));
-                        float d                 = ccl::dot(ccl::make_float3(0.0f, 0.0f, 1.0f),
+                        float d = ccl::dot(ccl::make_float3(0.0f, 0.0f, 1.0f),
                                            ccl::make_float3(normals[i][0], normals[i][1], normals[i][2]));
-                        float angle             = atan2f(ccl::len(rotAxis), d);
+                        float angle = atan2f(ccl::len(rotAxis), d);
                         m_cyclesObjects[i]->tfm = m_cyclesObjects[i]->tfm * ccl::transform_rotate((angle), rotAxis);
                     }
                 }
@@ -264,7 +264,7 @@ void
 HdCyclesPoints::_CreateDiscMesh()
 {
     m_cyclesMesh->clear();
-    m_cyclesMesh->name             = ccl::ustring("generated_disc");
+    m_cyclesMesh->name = ccl::ustring("generated_disc");
     m_cyclesMesh->subdivision_type = ccl::Mesh::SUBDIVISION_NONE;
 
     int numVerts = m_pointResolution;
@@ -297,22 +297,22 @@ HdCyclesPoints::_CreateSphereMesh()
     float radius = 0.5f;
 
     int sectorCount = m_pointResolution;
-    int stackCount  = m_pointResolution;
+    int stackCount = m_pointResolution;
 
     m_cyclesMesh->clear();
-    m_cyclesMesh->name             = ccl::ustring("generated_sphere");
+    m_cyclesMesh->name = ccl::ustring("generated_sphere");
     m_cyclesMesh->subdivision_type = ccl::Mesh::SUBDIVISION_NONE;
 
     float z, xy;
 
     float sectorStep = 2.0f * M_PI_F / static_cast<float>(sectorCount);
-    float stackStep  = M_PI_F / static_cast<float>(stackCount);
+    float stackStep = M_PI_F / static_cast<float>(stackCount);
     float sectorAngle, stackAngle;
 
     for (int i = 0; i <= stackCount; ++i) {
         stackAngle = M_PI_F / 2.0f - static_cast<float>(i) * stackStep;
-        xy         = radius * cosf(stackAngle);
-        z          = radius * sinf(stackAngle);
+        xy = radius * cosf(stackAngle);
+        z = radius * sinf(stackAngle);
 
         for (int j = 0; j <= sectorCount; ++j) {
             sectorAngle = static_cast<float>(j) * sectorStep;
@@ -346,8 +346,8 @@ HdCyclesPoints::_CreatePointsObject(const ccl::Transform& transform, ccl::Mesh* 
 {
     /* create object*/
     ccl::Object* object = new ccl::Object();
-    object->geometry    = mesh;
-    object->tfm         = transform;
+    object->geometry = mesh;
+    object->tfm = transform;
     object->motion.clear();
 
     return object;

--- a/plugin/hdCycles/renderBuffer.cpp
+++ b/plugin/hdCycles/renderBuffer.cpp
@@ -33,8 +33,8 @@ _ConvertPixel(HdFormat dstFormat, uint8_t* dst, HdFormat srcFormat, uint8_t cons
 {
     HdFormat srcComponentFormat = HdGetComponentFormat(srcFormat);
     HdFormat dstComponentFormat = HdGetComponentFormat(dstFormat);
-    size_t srcComponentCount    = HdGetComponentCount(srcFormat);
-    size_t dstComponentCount    = HdGetComponentCount(dstFormat);
+    size_t srcComponentCount = HdGetComponentCount(srcFormat);
+    size_t dstComponentCount = HdGetComponentCount(dstFormat);
 
     for (size_t c = 0; c < dstComponentCount; ++c) {
         T readValue = 0;
@@ -96,9 +96,9 @@ HdCyclesRenderBuffer::Allocate(const GfVec3i& dimensions, HdFormat format, bool 
         return false;
     }
 
-    m_width     = static_cast<unsigned int>(dimensions[0]);
-    m_height    = static_cast<unsigned int>(dimensions[1]);
-    m_format    = format;
+    m_width = static_cast<unsigned int>(dimensions[0]);
+    m_height = static_cast<unsigned int>(dimensions[1]);
+    m_format = format;
     m_pixelSize = static_cast<unsigned int>(HdDataSizeOfFormat(format));
     m_buffer.resize(m_width * m_height * m_pixelSize, 0);
 
@@ -197,7 +197,7 @@ HdCyclesRenderBuffer::Blit(HdFormat format, int width, int height, int offset, i
     } else {
         // Convert pixel by pixel, with nearest point sampling.
         // If src and dst are both int-based, don't round trip to float.
-        size_t pixelSize  = HdDataSizeOfFormat(format);
+        size_t pixelSize = HdDataSizeOfFormat(format);
         bool convertAsInt = (HdGetComponentFormat(format) == HdFormatInt32)
                             && (HdGetComponentFormat(m_format) == HdFormatInt32);
 
@@ -289,9 +289,9 @@ void
 HdCyclesRenderBuffer::_Deallocate()
 {
     m_wasUpdated = true;
-    m_width      = 0;
-    m_height     = 0;
-    m_format     = HdFormatInvalid;
+    m_width = 0;
+    m_height = 0;
+    m_format = HdFormatInvalid;
     m_buffer.resize(0);
     m_mappers.store(0);
     m_converged.store(false);

--- a/plugin/hdCycles/renderDelegate.cpp
+++ b/plugin/hdCycles/renderDelegate.cpp
@@ -120,18 +120,15 @@ HdCyclesRenderDelegate::_Initialize(HdRenderSettingsMap const& settingsMap)
         return;
 
     // -- Initialize Render Delegate components
-    std::lock_guard<std::mutex> guard{m_resource_registry_mutex};
-    if(m_resource_registry_counter.fetch_add(1) == 0) {
+    std::lock_guard<std::mutex> guard { m_resource_registry_mutex };
+    if (m_resource_registry_counter.fetch_add(1) == 0) {
         m_resourceRegistry = std::make_shared<HdCyclesResourceRegistry>();
     }
 
     m_resourceRegistry->UpdateScene(m_renderParam->GetCyclesScene());
 }
 
-HdCyclesRenderDelegate::~HdCyclesRenderDelegate()
-{
-    m_renderParam->StopRender();
-}
+HdCyclesRenderDelegate::~HdCyclesRenderDelegate() { m_renderParam->StopRender(); }
 
 TfTokenVector const&
 HdCyclesRenderDelegate::GetSupportedRprimTypes() const
@@ -198,7 +195,7 @@ HdRenderPassSharedPtr
 HdCyclesRenderDelegate::CreateRenderPass(HdRenderIndex* index, HdRprimCollection const& collection)
 {
     HdRenderPassSharedPtr xx = HdRenderPassSharedPtr(new HdCyclesRenderPass(this, index, collection));
-    m_renderPass             = static_cast<HdCyclesRenderPass*>(xx.get());
+    m_renderPass = static_cast<HdCyclesRenderPass*>(xx.get());
     return xx;
 }
 
@@ -217,7 +214,7 @@ HdCyclesRenderDelegate::CommitResources(HdChangeTracker* tracker)
 
     // commit resource to the scene
     m_resourceRegistry->Commit();
-    if(tracker->IsGarbageCollectionNeeded()) {
+    if (tracker->IsGarbageCollectionNeeded()) {
         m_resourceRegistry->GarbageCollect();
         tracker->ClearGarbageCollectionNeeded();
     }
@@ -350,7 +347,7 @@ HdCyclesRenderDelegate::GetCyclesRenderParam() const
 HdAovDescriptor
 HdCyclesRenderDelegate::GetDefaultAovDescriptor(TfToken const& name) const
 {
-    bool use_tiles  = GetCyclesRenderParam()->IsTiledRender();
+    bool use_tiles = GetCyclesRenderParam()->IsTiledRender();
     bool use_linear = GetCyclesRenderParam()->GetCyclesSession()->params.display_buffer_linear;
 
     HdFormat colorFormat = use_linear ? HdFormatFloat16Vec4 : HdFormatUNorm8Vec4;

--- a/plugin/hdCycles/renderParam.cpp
+++ b/plugin/hdCycles/renderParam.cpp
@@ -182,9 +182,9 @@ HdCyclesRenderParam::_InitializeDefaults()
     // These aren't directly cycles settings, but inform the creation and behaviour
     // of a render. These should be will need to be set by schema too...
     static const HdCyclesConfig& config = HdCyclesConfig::GetInstance();
-    m_deviceName                        = config.device_name.value;
-    m_useSquareSamples                  = config.use_square_samples.value;
-    m_useTiledRendering                 = config.use_tiled_rendering;
+    m_deviceName = config.device_name.value;
+    m_useSquareSamples = config.use_square_samples.value;
+    m_useTiledRendering = config.use_tiled_rendering;
 
     m_upAxis = UpAxis::Z;
     if (config.up_axis == "Z") {
@@ -318,7 +318,7 @@ void
 HdCyclesRenderParam::_UpdateDelegateFromRenderSettings(HdRenderSettingsMap const& settingsMap)
 {
     for (auto& entry : settingsMap) {
-        TfToken key   = entry.first;
+        TfToken key = entry.first;
         VtValue value = entry.second;
         _HandleDelegateRenderSetting(key, value);
     }
@@ -365,8 +365,8 @@ HdCyclesRenderParam::_UpdateSessionFromConfig(bool a_forceInit)
 
     config.start_resolution.eval(sessionParams->start_resolution, a_forceInit);
 
-    sessionParams->progressive                = true;
-    sessionParams->progressive_refine         = false;
+    sessionParams->progressive = true;
+    sessionParams->progressive_refine = false;
     sessionParams->progressive_update_timeout = 0.1;
 
     config.pixel_size.eval(sessionParams->pixel_size, a_forceInit);
@@ -377,9 +377,9 @@ HdCyclesRenderParam::_UpdateSessionFromConfig(bool a_forceInit)
     // This requires some more thought and testing in regards
     // to the usdCycles schema...
     if (m_useTiledRendering) {
-        sessionParams->background         = true;
-        sessionParams->start_resolution   = INT_MAX;
-        sessionParams->progressive        = false;
+        sessionParams->background = true;
+        sessionParams->start_resolution = INT_MAX;
+        sessionParams->progressive = false;
         sessionParams->progressive_refine = false;
     }
 
@@ -390,7 +390,7 @@ void
 HdCyclesRenderParam::_UpdateSessionFromRenderSettings(HdRenderSettingsMap const& settingsMap)
 {
     for (auto& entry : settingsMap) {
-        TfToken key   = entry.first;
+        TfToken key = entry.first;
         VtValue value = entry.second;
         _HandleSessionRenderSetting(key, value);
     }
@@ -436,12 +436,12 @@ HdCyclesRenderParam::_HandleSessionRenderSetting(const TfToken& key, const VtVal
     if (key == usdCyclesTokens->cyclesSamples) {
         // If branched-path mode is set, make sure to set samples to use the
         // aa_samples instead from the integrator.
-        int samples                    = sessionParams->samples;
-        int aa_samples                 = 0;
+        int samples = sessionParams->samples;
+        int aa_samples = 0;
         ccl::Integrator::Method method = ccl::Integrator::PATH;
 
         if (m_cyclesScene) {
-            method     = m_cyclesScene->integrator->method;
+            method = m_cyclesScene->integrator->method;
             aa_samples = m_cyclesScene->integrator->aa_samples;
 
             // Don't apply aa_samples if it is 0
@@ -556,7 +556,7 @@ HdCyclesRenderParam::_HandleSessionRenderSetting(const TfToken& key, const VtVal
 
     if (denoising_updated) {
         sessionParams->denoising = denoisingParams;
-        session_updated          = true;
+        session_updated = true;
     }
 
     // Final
@@ -605,7 +605,7 @@ void
 HdCyclesRenderParam::_UpdateSceneFromRenderSettings(HdRenderSettingsMap const& settingsMap)
 {
     for (auto& entry : settingsMap) {
-        TfToken key   = entry.first;
+        TfToken key = entry.first;
         VtValue value = entry.second;
         _HandleSceneRenderSetting(key, value);
     }
@@ -737,7 +737,7 @@ void
 HdCyclesRenderParam::_UpdateIntegratorFromRenderSettings(HdRenderSettingsMap const& settingsMap)
 {
     for (auto& entry : settingsMap) {
-        TfToken key   = entry.first;
+        TfToken key = entry.first;
         VtValue value = entry.second;
 
         _HandleIntegratorRenderSetting(key, value);
@@ -750,8 +750,8 @@ HdCyclesRenderParam::_HandleIntegratorRenderSetting(const TfToken& key, const Vt
     // -- Integrator Settings
 
     ccl::Integrator* integrator = m_cyclesScene->integrator;
-    bool integrator_updated     = false;
-    bool method_updated         = false;
+    bool integrator_updated = false;
+    bool method_updated = false;
 
     if (key == usdCyclesTokens->cyclesIntegratorSeed) {
         integrator->seed = _HdCyclesGetVtValue<int>(value, integrator->seed, &integrator_updated);
@@ -800,7 +800,7 @@ HdCyclesRenderParam::_HandleIntegratorRenderSetting(const TfToken& key, const Vt
 
         // Adaptive sampling must use PMJ
         if (m_cyclesSession->params.adaptive_sampling && integrator->sampling_pattern != ccl::SAMPLING_PATTERN_PMJ) {
-            integrator_updated           = true;
+            integrator_updated = true;
             integrator->sampling_pattern = ccl::SAMPLING_PATTERN_PMJ;
         }
     }
@@ -855,7 +855,7 @@ HdCyclesRenderParam::_HandleIntegratorRenderSetting(const TfToken& key, const Vt
     // Samples
 
     if (key == usdCyclesTokens->cyclesIntegratorAa_samples) {
-        bool sample_updated    = false;
+        bool sample_updated = false;
         integrator->aa_samples = _HdCyclesGetVtValue<int>(value, integrator->aa_samples, &sample_updated);
 
         if (sample_updated) {
@@ -870,7 +870,7 @@ HdCyclesRenderParam::_HandleIntegratorRenderSetting(const TfToken& key, const Vt
     }
 
     if (key == usdCyclesTokens->cyclesIntegratorAdaptive_min_samples) {
-        bool sample_updated              = false;
+        bool sample_updated = false;
         integrator->adaptive_min_samples = _HdCyclesGetVtValue<int>(value, integrator->adaptive_min_samples,
                                                                     &sample_updated);
 
@@ -884,7 +884,7 @@ HdCyclesRenderParam::_HandleIntegratorRenderSetting(const TfToken& key, const Vt
     }
 
     if (key == usdCyclesTokens->cyclesIntegratorDiffuse_samples) {
-        bool sample_updated         = false;
+        bool sample_updated = false;
         integrator->diffuse_samples = _HdCyclesGetVtValue<int>(value, integrator->diffuse_samples, &sample_updated);
 
         if (sample_updated) {
@@ -896,7 +896,7 @@ HdCyclesRenderParam::_HandleIntegratorRenderSetting(const TfToken& key, const Vt
     }
 
     if (key == usdCyclesTokens->cyclesIntegratorGlossy_samples) {
-        bool sample_updated        = false;
+        bool sample_updated = false;
         integrator->glossy_samples = _HdCyclesGetVtValue<int>(value, integrator->glossy_samples, &sample_updated);
 
         if (sample_updated) {
@@ -908,7 +908,7 @@ HdCyclesRenderParam::_HandleIntegratorRenderSetting(const TfToken& key, const Vt
     }
 
     if (key == usdCyclesTokens->cyclesIntegratorTransmission_samples) {
-        bool sample_updated              = false;
+        bool sample_updated = false;
         integrator->transmission_samples = _HdCyclesGetVtValue<int>(value, integrator->transmission_samples,
                                                                     &sample_updated);
 
@@ -921,7 +921,7 @@ HdCyclesRenderParam::_HandleIntegratorRenderSetting(const TfToken& key, const Vt
     }
 
     if (key == usdCyclesTokens->cyclesIntegratorAo_samples) {
-        bool sample_updated    = false;
+        bool sample_updated = false;
         integrator->ao_samples = _HdCyclesGetVtValue<int>(value, integrator->ao_samples, &sample_updated);
 
         if (sample_updated) {
@@ -933,7 +933,7 @@ HdCyclesRenderParam::_HandleIntegratorRenderSetting(const TfToken& key, const Vt
     }
 
     if (key == usdCyclesTokens->cyclesIntegratorMesh_light_samples) {
-        bool sample_updated            = false;
+        bool sample_updated = false;
         integrator->mesh_light_samples = _HdCyclesGetVtValue<int>(value, integrator->mesh_light_samples,
                                                                   &sample_updated);
 
@@ -946,7 +946,7 @@ HdCyclesRenderParam::_HandleIntegratorRenderSetting(const TfToken& key, const Vt
     }
 
     if (key == usdCyclesTokens->cyclesIntegratorSubsurface_samples) {
-        bool sample_updated            = false;
+        bool sample_updated = false;
         integrator->subsurface_samples = _HdCyclesGetVtValue<int>(value, integrator->subsurface_samples,
                                                                   &sample_updated);
 
@@ -959,7 +959,7 @@ HdCyclesRenderParam::_HandleIntegratorRenderSetting(const TfToken& key, const Vt
     }
 
     if (key == usdCyclesTokens->cyclesIntegratorVolume_samples) {
-        bool sample_updated        = false;
+        bool sample_updated = false;
         integrator->volume_samples = _HdCyclesGetVtValue<int>(value, integrator->volume_samples, &sample_updated);
 
         if (sample_updated) {
@@ -1047,7 +1047,7 @@ void
 HdCyclesRenderParam::_UpdateFilmFromRenderSettings(HdRenderSettingsMap const& settingsMap)
 {
     for (auto& entry : settingsMap) {
-        TfToken key   = entry.first;
+        TfToken key = entry.first;
         VtValue value = entry.second;
 
         _HandleFilmRenderSetting(key, value);
@@ -1059,7 +1059,7 @@ HdCyclesRenderParam::_HandleFilmRenderSetting(const TfToken& key, const VtValue&
 {
     // -- Film Settings
 
-    ccl::Film* film   = m_cyclesScene->film;
+    ccl::Film* film = m_cyclesScene->film;
     bool film_updated = false;
 
     if (key == usdCyclesTokens->cyclesFilmExposure) {
@@ -1117,7 +1117,7 @@ HdCyclesRenderParam::_HandleFilmRenderSetting(const TfToken& key, const VtValue&
     }
 
     if (key == usdCyclesTokens->cyclesFilmCryptomatte_depth) {
-        auto cryptomatte_depth  = _HdCyclesGetVtValue<int>(value, 4, &film_updated, false);
+        auto cryptomatte_depth = _HdCyclesGetVtValue<int>(value, 4, &film_updated, false);
         film->cryptomatte_depth = static_cast<int>(
             ccl::divide_up(static_cast<size_t>(ccl::min(16, cryptomatte_depth)), 2));
     }
@@ -1151,7 +1151,7 @@ void
 HdCyclesRenderParam::_UpdateBackgroundFromRenderSettings(HdRenderSettingsMap const& settingsMap)
 {
     for (auto& entry : settingsMap) {
-        TfToken key   = entry.first;
+        TfToken key = entry.first;
         VtValue value = entry.second;
         _HandleBackgroundRenderSetting(key, value);
     }
@@ -1163,7 +1163,7 @@ HdCyclesRenderParam::_HandleBackgroundRenderSetting(const TfToken& key, const Vt
     // -- Background Settings
 
     ccl::Background* background = m_cyclesScene->background;
-    bool background_updated     = false;
+    bool background_updated = false;
 
     if (key == usdCyclesTokens->cyclesBackgroundAo_factor) {
         background->ao_factor = _HdCyclesGetVtValue<float>(value, background->ao_factor, &background_updated);
@@ -1279,7 +1279,7 @@ HdCyclesRenderParam::_CreateSession()
 
     m_cyclesSession = new ccl::Session(m_sessionParams);
 
-    m_cyclesSession->write_render_tile_cb  = std::bind(&HdCyclesRenderParam::_WriteRenderTile, this, ccl::_1);
+    m_cyclesSession->write_render_tile_cb = std::bind(&HdCyclesRenderParam::_WriteRenderTile, this, ccl::_1);
     m_cyclesSession->update_render_tile_cb = std::bind(&HdCyclesRenderParam::_UpdateRenderTile, this, ccl::_1, ccl::_2);
 
     m_cyclesSession->progress.set_update_callback(std::bind(&HdCyclesRenderParam::_SessionUpdateCallback, this));
@@ -1307,7 +1307,7 @@ HdCyclesRenderParam::_WriteRenderTile(ccl::RenderTile& rtile)
         return;
 
     // Adjust absolute sample number to the range.
-    int sample                   = rtile.sample;
+    int sample = rtile.sample;
     const int range_start_sample = m_cyclesSession->tile_manager.range_start_sample;
     if (range_start_sample != -1) {
         sample -= range_start_sample;
@@ -1389,19 +1389,19 @@ HdCyclesRenderParam::_CreateScene()
 
     m_cyclesScene = new ccl::Scene(m_sceneParams, m_cyclesSession->device);
 
-    m_width  = config.render_width.value;
+    m_width = config.render_width.value;
     m_height = config.render_height.value;
 
-    m_cyclesScene->camera->width  = m_width;
+    m_cyclesScene->camera->width = m_width;
     m_cyclesScene->camera->height = m_height;
 
     m_cyclesScene->camera->compute_auto_viewplane();
 
     m_cyclesSession->scene = m_cyclesScene;
 
-    m_bufferParams.width       = m_width;
-    m_bufferParams.height      = m_height;
-    m_bufferParams.full_width  = m_width;
+    m_bufferParams.width = m_width;
+    m_bufferParams.height = m_height;
+    m_bufferParams.full_width = m_width;
     m_bufferParams.full_height = m_height;
 
     default_attrib_display_color_surface = HdCyclesCreateAttribColorSurface();
@@ -1490,12 +1490,12 @@ HdCyclesRenderParam::SetBackgroundShader(ccl::Shader* a_shader, bool a_emissive)
         // TODO: These aren't properly destroyed from memory
 
         // Create empty background shader
-        m_cyclesScene->default_background        = new ccl::Shader();
-        m_cyclesScene->default_background->name  = "default_background";
+        m_cyclesScene->default_background = new ccl::Shader();
+        m_cyclesScene->default_background->name = "default_background";
         m_cyclesScene->default_background->graph = new ccl::ShaderGraph();
         if (a_emissive) {
             ccl::BackgroundNode* bgNode = new ccl::BackgroundNode();
-            bgNode->color               = ccl::make_float3(0.6f, 0.6f, 0.6f);
+            bgNode->color = ccl::make_float3(0.6f, 0.6f, 0.6f);
 
             m_cyclesScene->default_background->graph->add(bgNode);
 
@@ -1553,7 +1553,7 @@ HdCyclesRenderParam::_SetDevice(const ccl::DeviceType& a_deviceType, ccl::Sessio
     bool device_available = false;
 
     if (!devices.empty()) {
-        params.device    = devices.front();
+        params.device = devices.front();
         device_available = true;
     }
 
@@ -1629,17 +1629,17 @@ HdCyclesRenderParam::CyclesReset(bool a_forceUpdate)
 void
 HdCyclesRenderParam::SetViewport(int w, int h)
 {
-    m_width  = w;
+    m_width = w;
     m_height = h;
 
-    m_bufferParams.width          = m_width;
-    m_bufferParams.height         = m_height;
-    m_bufferParams.full_width     = m_width;
-    m_bufferParams.full_height    = m_height;
-    m_cyclesScene->camera->width  = m_width;
+    m_bufferParams.width = m_width;
+    m_bufferParams.height = m_height;
+    m_bufferParams.full_width = m_width;
+    m_bufferParams.full_height = m_height;
+    m_cyclesScene->camera->width = m_width;
     m_cyclesScene->camera->height = m_height;
     m_cyclesScene->camera->compute_auto_viewplane();
-    m_cyclesScene->camera->need_update        = true;
+    m_cyclesScene->camera->need_update = true;
     m_cyclesScene->camera->need_device_update = true;
 
     m_aovBindingsNeedValidation = true;
@@ -1903,8 +1903,8 @@ HdCyclesRenderParam::GetRenderStats() const
 
     // We need to store the cryptomatte metadata here, based on if there's any Cryptomatte AOVs
 
-    bool cryptoAsset    = false;
-    bool cryptoObject   = false;
+    bool cryptoAsset = false;
+    bool cryptoObject = false;
     bool cryptoMaterial = false;
 
     for (const HdRenderPassAovBinding& aov : m_aovs) {
@@ -1924,37 +1924,37 @@ HdCyclesRenderParam::GetRenderStats() const
     }
 
     if (cryptoAsset) {
-        std::string cryptoName        = HdCyclesAovTokens->CryptoAsset.GetText();
-        auto cryptoNameLength         = static_cast<int>(cryptoName.length());
-        std::string identifier        = ccl::string_printf("%08x",
+        std::string cryptoName = HdCyclesAovTokens->CryptoAsset.GetText();
+        auto cryptoNameLength = static_cast<int>(cryptoName.length());
+        std::string identifier = ccl::string_printf("%08x",
                                                     ccl::util_murmur_hash3(cryptoName.c_str(), cryptoNameLength, 0));
-        std::string prefix            = "cryptomatte/" + identifier.substr(0, 7) + "/";
-        result[prefix + "name"]       = VtValue(cryptoName);
-        result[prefix + "hash"]       = VtValue("MurmurHash3_32");
+        std::string prefix = "cryptomatte/" + identifier.substr(0, 7) + "/";
+        result[prefix + "name"] = VtValue(cryptoName);
+        result[prefix + "hash"] = VtValue("MurmurHash3_32");
         result[prefix + "conversion"] = VtValue("uint32_to_float32");
-        result[prefix + "manifest"]   = VtValue(m_cyclesScene->object_manager->get_cryptomatte_assets(m_cyclesScene));
+        result[prefix + "manifest"] = VtValue(m_cyclesScene->object_manager->get_cryptomatte_assets(m_cyclesScene));
     }
 
     if (cryptoObject) {
-        std::string cryptoName        = HdCyclesAovTokens->CryptoObject.GetText();
-        auto cryptoNameLength         = static_cast<int>(cryptoName.length());
-        std::string identifier        = ccl::string_printf("%08x",
+        std::string cryptoName = HdCyclesAovTokens->CryptoObject.GetText();
+        auto cryptoNameLength = static_cast<int>(cryptoName.length());
+        std::string identifier = ccl::string_printf("%08x",
                                                     ccl::util_murmur_hash3(cryptoName.c_str(), cryptoNameLength, 0));
-        std::string prefix            = "cryptomatte/" + identifier.substr(0, 7) + "/";
-        result[prefix + "name"]       = VtValue(cryptoName);
-        result[prefix + "hash"]       = VtValue("MurmurHash3_32");
+        std::string prefix = "cryptomatte/" + identifier.substr(0, 7) + "/";
+        result[prefix + "name"] = VtValue(cryptoName);
+        result[prefix + "hash"] = VtValue("MurmurHash3_32");
         result[prefix + "conversion"] = VtValue("uint32_to_float32");
-        result[prefix + "manifest"]   = VtValue(m_cyclesScene->object_manager->get_cryptomatte_objects(m_cyclesScene));
+        result[prefix + "manifest"] = VtValue(m_cyclesScene->object_manager->get_cryptomatte_objects(m_cyclesScene));
     }
 
     if (cryptoMaterial) {
-        std::string cryptoName        = HdCyclesAovTokens->CryptoMaterial.GetText();
-        auto cryptoNameLength         = static_cast<int>(cryptoName.length());
-        std::string identifier        = ccl::string_printf("%08x",
+        std::string cryptoName = HdCyclesAovTokens->CryptoMaterial.GetText();
+        auto cryptoNameLength = static_cast<int>(cryptoName.length());
+        std::string identifier = ccl::string_printf("%08x",
                                                     ccl::util_murmur_hash3(cryptoName.c_str(), cryptoNameLength, 0));
-        std::string prefix            = "cryptomatte/" + identifier.substr(0, 7) + "/";
-        result[prefix + "name"]       = VtValue(cryptoName);
-        result[prefix + "hash"]       = VtValue("MurmurHash3_32");
+        std::string prefix = "cryptomatte/" + identifier.substr(0, 7) + "/";
+        result[prefix + "name"] = VtValue(cryptoName);
+        result[prefix + "hash"] = VtValue("MurmurHash3_32");
         result[prefix + "conversion"] = VtValue("uint32_to_float32");
         result[prefix + "manifest"] = VtValue(m_cyclesScene->shader_manager->get_cryptomatte_materials(m_cyclesScene));
     }
@@ -1967,9 +1967,9 @@ HdCyclesRenderParam::SetAovBindings(HdRenderPassAovBindingVector const& a_aovs)
 {
     m_aovs = a_aovs;
     m_bufferParams.passes.clear();
-    bool has_combined     = false;
+    bool has_combined = false;
     bool has_sample_count = false;
-    ccl::Film* film       = m_cyclesScene->film;
+    ccl::Film* film = m_cyclesScene->film;
 
     ccl::CryptomatteType cryptomatte_passes = ccl::CRYPT_NONE;
     if (film->cryptomatte_passes & ccl::CRYPT_ACCURATE) {
@@ -1977,9 +1977,9 @@ HdCyclesRenderParam::SetAovBindings(HdRenderPassAovBindingVector const& a_aovs)
     }
     film->cryptomatte_passes = cryptomatte_passes;
 
-    int cryptoObject   = 0;
+    int cryptoObject = 0;
     int cryptoMaterial = 0;
-    int cryptoAsset    = 0;
+    int cryptoAsset = 0;
 
     for (const HdRenderPassAovBinding& aov : m_aovs) {
         TfToken sourceName = GetSourceName(aov);
@@ -2075,13 +2075,13 @@ void
 HdCyclesRenderParam::SetDisplayAov(HdRenderPassAovBinding const& a_aov)
 {
     m_cyclesScene->film->display_pass = DefaultAovs[0].type;
-    m_displayAovToken                 = DefaultAovs[0].token;
+    m_displayAovToken = DefaultAovs[0].token;
     if (!m_aovs.empty()) {
         TfToken sourceName = GetSourceName(a_aov);
         for (HdCyclesAov& cyclesAov : DefaultAovs) {
             if (sourceName == cyclesAov.token) {
                 m_cyclesScene->film->display_pass = cyclesAov.type;
-                m_displayAovToken                 = a_aov.aovName;
+                m_displayAovToken = a_aov.aovName;
                 break;
             }
         }

--- a/plugin/hdCycles/renderPass.cpp
+++ b/plugin/hdCycles/renderPass.cpp
@@ -78,8 +78,7 @@ HdCyclesRenderPass::_Execute(HdRenderPassStateSharedPtr const& renderPassState, 
 
     // TODO: Revisit this code and move it to HdCyclesRenderPassState
     auto hdCam = const_cast<HdCyclesCamera*>(dynamic_cast<HdCyclesCamera const*>(renderPassState->GetCamera()));
-    if(hdCam) {
-
+    if (hdCam) {
         GfMatrix4d projMtx = renderPassState->GetProjectionMatrix();
         GfMatrix4d viewMtx = renderPassState->GetWorldToViewMatrix();
 
@@ -119,11 +118,11 @@ HdCyclesRenderPass::_Execute(HdRenderPassStateSharedPtr const& renderPassState, 
     }
 
     const GfVec4f& viewport = renderPassState->GetViewport();
-    const auto width  = static_cast<int>(viewport[2]);
+    const auto width = static_cast<int>(viewport[2]);
     const auto height = static_cast<int>(viewport[3]);
 
     if (width != m_width || height != m_height) {
-        m_width  = width;
+        m_width = width;
         m_height = height;
 
         // TODO: Due to the startup flow of Cycles, this gets called after a tiled render

--- a/plugin/hdCycles/renderPass.h
+++ b/plugin/hdCycles/renderPass.h
@@ -75,7 +75,7 @@ protected:
     GfMatrix4d m_viewMtx;
 
 public:
-    int m_width  = 0;
+    int m_width = 0;
     int m_height = 0;
 
     bool m_isConverged = false;

--- a/plugin/hdCycles/renderPassState.cpp
+++ b/plugin/hdCycles/renderPassState.cpp
@@ -32,7 +32,7 @@ void
 HdCyclesRenderPassState::Prepare(const HdResourceRegistrySharedPtr& resourceRegistry)
 {
     HdCyclesResourceRegistry* registry = dynamic_cast<HdCyclesResourceRegistry*>(resourceRegistry.get());
-    if(!registry) {
+    if (!registry) {
         return;
     }
 

--- a/plugin/hdCycles/resourceRegistry.h
+++ b/plugin/hdCycles/resourceRegistry.h
@@ -36,7 +36,6 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 class HdCyclesResourceRegistry final : public HdResourceRegistry {
 public:
-
     HdCyclesResourceRegistry() = default;
 
     void UpdateScene(ccl::Scene* scene) { m_scene = scene; }
@@ -47,7 +46,7 @@ private:
     void _Commit() override;
     void _GarbageCollect() override;
 
-    ccl::Scene* m_scene{};
+    ccl::Scene* m_scene {};
     HdInstanceRegistry<HdCyclesObjectSourceSharedPtr> m_object_sources;
 };
 

--- a/plugin/hdCycles/utils.cpp
+++ b/plugin/hdCycles/utils.cpp
@@ -64,7 +64,7 @@ HdCyclesParseUDIMS(const ccl::string& a_filepath, ccl::vector<int>& a_tiles)
 {
     BOOST_NS::filesystem::path filepath(a_filepath);
 
-    size_t offset            = filepath.stem().string().find("<UDIM>");
+    size_t offset = filepath.stem().string().find("<UDIM>");
     std::string baseFileName = filepath.stem().string().substr(0, offset);
 
     std::vector<std::string> files;
@@ -91,7 +91,7 @@ void
 HdCyclesMeshTextureSpace(ccl::Geometry* a_geom, ccl::float3& a_loc, ccl::float3& a_size)
 {
     // m_cyclesMesh->compute_bounds must be called before this
-    a_loc  = (a_geom->bounds.max + a_geom->bounds.min) / 2.0f;
+    a_loc = (a_geom->bounds.max + a_geom->bounds.min) / 2.0f;
     a_size = (a_geom->bounds.max - a_geom->bounds.min) / 2.0f;
 
     if (a_size.x != 0.0f)
@@ -114,7 +114,7 @@ HdCyclesCreateDefaultShader()
     shader->graph = new ccl::ShaderGraph();
 
     ccl::VertexColorNode* vc = new ccl::VertexColorNode();
-    vc->layer_name           = ccl::ustring("displayColor");
+    vc->layer_name = ccl::ustring("displayColor");
 
     ccl::PrincipledBsdfNode* bsdf = new ccl::PrincipledBsdfNode();
 
@@ -131,10 +131,10 @@ HdCyclesCreateDefaultShader()
 ccl::Shader*
 HdCyclesCreateObjectColorSurface()
 {
-    auto shader   = new ccl::Shader();
+    auto shader = new ccl::Shader();
     shader->graph = new ccl::ShaderGraph();
 
-    auto oi   = new ccl::ObjectInfoNode {};
+    auto oi = new ccl::ObjectInfoNode {};
     auto bsdf = new ccl::PrincipledBsdfNode();
 
     shader->graph->add(bsdf);
@@ -150,10 +150,10 @@ HdCyclesCreateObjectColorSurface()
 ccl::Shader*
 HdCyclesCreateAttribColorSurface()
 {
-    auto shader   = new ccl::Shader();
+    auto shader = new ccl::Shader();
     shader->graph = new ccl::ShaderGraph();
 
-    auto attrib       = new ccl::AttributeNode {};
+    auto attrib = new ccl::AttributeNode {};
     attrib->attribute = "displayColor";
 
     auto bsdf = new ccl::PrincipledBsdfNode();
@@ -236,9 +236,9 @@ HdCyclesSetTransform(ccl::Object* object, HdSceneDelegate* delegate, const SdfPa
         }
 
         // Rounding to odd number of samples to have one in the center
-        const size_t sampleOffset   = (sampleCount % 2) ? 0 : 1;
+        const size_t sampleOffset = (sampleCount % 2) ? 0 : 1;
         const size_t numMotionSteps = sampleCount + static_cast<size_t>(sampleOffset);
-        const float motionStepSize  = (xf.times.back() - xf.times.front()) / static_cast<float>((numMotionSteps - 1));
+        const float motionStepSize = (xf.times.back() - xf.times.front()) / static_cast<float>((numMotionSteps - 1));
         object->motion.resize(numMotionSteps, ccl::transform_empty());
 
         // For each step, we use the available data from the neighbors
@@ -266,10 +266,10 @@ HdCyclesSetTransform(ccl::Object* object, HdSceneDelegate* delegate, const SdfPa
 
                 const float stepTimeDiff = xf.times.data()[j] - stepTime;
                 if (stepTimeDiff < 0 && stepTimeDiff > prevTimeDiff) {
-                    iXfPrev      = j;
+                    iXfPrev = j;
                     prevTimeDiff = stepTimeDiff;
                 } else if (stepTimeDiff > 0 && stepTimeDiff < nextTimeDiff) {
-                    iXfNext      = j;
+                    iXfNext = j;
                     nextTimeDiff = stepTimeDiff;
                 }
             }
@@ -297,7 +297,7 @@ HdCyclesSetTransform(ccl::Object* object, HdSceneDelegate* delegate, const SdfPa
 
                 // Weighting by distance to sample
                 const float timeDiff = xf.times.data()[iXfNext] - xf.times.data()[iXfPrev];
-                const float t        = (stepTime - xf.times.data()[iXfPrev]) / timeDiff;
+                const float t = (stepTime - xf.times.data()[iXfPrev]) / timeDiff;
 
                 transform_motion_array_interpolate(&object->motion[i], dxf, 2, t);
             }
@@ -328,7 +328,7 @@ ConvertCameraTransform(const GfMatrix4d& a_cameraTransform)
     GfMatrix4d viewToWorldCorrectionMatrix(1.0);
 
     GfMatrix4d flipZ(1.0);
-    flipZ[2][2]                 = -1.0;
+    flipZ[2][2] = -1.0;
     viewToWorldCorrectionMatrix = flipZ * viewToWorldCorrectionMatrix;
 
     return viewToWorldCorrectionMatrix * a_cameraTransform;
@@ -517,10 +517,10 @@ _HdCyclesInsertPrimvar(HdCyclesPrimvarMap& primvars, const TfToken& name, const 
     if (it == primvars.end()) {
         primvars.insert({ name, { value, role, interpolation } });
     } else {
-        it->second.value         = value;
-        it->second.role          = role;
+        it->second.value = value;
+        it->second.role = role;
         it->second.interpolation = interpolation;
-        it->second.dirtied       = true;
+        it->second.dirtied = true;
     }
 }
 
@@ -546,7 +546,7 @@ HdCyclesGetComputedPrimvars(HdSceneDelegate* a_delegate, const SdfPath& a_id, Hd
         return false;
     }
 
-    auto changed    = false;
+    auto changed = false;
     auto valueStore = HdExtComputationUtils::GetComputedPrimvarValues(dirtyPrimvars, a_delegate);
     for (const auto& primvar : dirtyPrimvars) {
         const auto itComputed = valueStore.find(primvar.name);
@@ -813,24 +813,24 @@ void
 mikk_get_position(const SMikkTSpaceContext* context, float P[3], const int face_num, const int vert_num)
 {
     const MikkUserData* userdata = static_cast<const MikkUserData*>(context->m_pUserData);
-    const ccl::Mesh* mesh        = userdata->mesh;
-    const int vertex_index       = mikk_vertex_index(mesh, face_num, vert_num);
-    const ccl::float3 vP         = mesh->verts[vertex_index];
-    P[0]                         = vP.x;
-    P[1]                         = vP.y;
-    P[2]                         = vP.z;
+    const ccl::Mesh* mesh = userdata->mesh;
+    const int vertex_index = mikk_vertex_index(mesh, face_num, vert_num);
+    const ccl::float3 vP = mesh->verts[vertex_index];
+    P[0] = vP.x;
+    P[1] = vP.y;
+    P[2] = vP.z;
 }
 
 void
 mikk_get_texture_coordinate(const SMikkTSpaceContext* context, float uv[2], const int face_num, const int vert_num)
 {
     const MikkUserData* userdata = static_cast<const MikkUserData*>(context->m_pUserData);
-    const ccl::Mesh* mesh        = userdata->mesh;
+    const ccl::Mesh* mesh = userdata->mesh;
     if (userdata->texface != NULL) {
         const int corner_index = mikk_corner_index(mesh, face_num, vert_num);
-        ccl::float2 tfuv       = userdata->texface[corner_index];
-        uv[0]                  = tfuv.x;
-        uv[1]                  = tfuv.y;
+        ccl::float2 tfuv = userdata->texface[corner_index];
+        uv[0] = tfuv.x;
+        uv[1] = tfuv.y;
     } else {
         uv[0] = 0.0f;
         uv[1] = 0.0f;
@@ -841,7 +841,7 @@ void
 mikk_get_normal(const SMikkTSpaceContext* context, float N[3], const int face_num, const int vert_num)
 {
     const MikkUserData* userdata = static_cast<const MikkUserData*>(context->m_pUserData);
-    const ccl::Mesh* mesh        = userdata->mesh;
+    const ccl::Mesh* mesh = userdata->mesh;
     ccl::float3 vN;
 
     if (mesh->subd_faces.size()) {
@@ -850,7 +850,7 @@ mikk_get_normal(const SMikkTSpaceContext* context, float N[3], const int face_nu
             vN = userdata->corner_normal[face.start_corner + vert_num];
         } else if (face.smooth) {
             const int vertex_index = mikk_vertex_index(mesh, face_num, vert_num);
-            vN                     = userdata->vertex_normal[vertex_index];
+            vN = userdata->vertex_normal[vertex_index];
         } else {
             vN = face.normal(mesh);
         }
@@ -859,10 +859,10 @@ mikk_get_normal(const SMikkTSpaceContext* context, float N[3], const int face_nu
             vN = userdata->corner_normal[face_num * 3 + vert_num];
         } else if (mesh->smooth[face_num]) {
             const int vertex_index = mikk_vertex_index(mesh, face_num, vert_num);
-            vN                     = userdata->vertex_normal[vertex_index];
+            vN = userdata->vertex_normal[vertex_index];
         } else {
             const ccl::Mesh::Triangle tri = mesh->get_triangle(face_num);
-            vN                            = tri.compute_normal(&mesh->verts[0]);
+            vN = tri.compute_normal(&mesh->verts[0]);
         }
     }
     N[0] = vN.x;
@@ -874,9 +874,9 @@ void
 mikk_set_tangent_space(const SMikkTSpaceContext* context, const float T[], const float sign, const int face_num,
                        const int vert_num)
 {
-    MikkUserData* userdata          = static_cast<MikkUserData*>(context->m_pUserData);
-    const ccl::Mesh* mesh           = userdata->mesh;
-    const int corner_index          = mikk_corner_index(mesh, face_num, vert_num);
+    MikkUserData* userdata = static_cast<MikkUserData*>(context->m_pUserData);
+    const ccl::Mesh* mesh = userdata->mesh;
+    const int corner_index = mikk_corner_index(mesh, face_num, vert_num);
     userdata->tangent[corner_index] = ccl::make_float3(T[0], T[1], T[2]);
     if (userdata->tangent_sign != NULL) {
         userdata->tangent_sign[corner_index] = sign;
@@ -927,16 +927,16 @@ mikk_compute_tangents(const char* layer_name, ccl::Mesh* mesh, bool need_sign, b
     /* Setup interface. */
     SMikkTSpaceInterface sm_interface;
     memset(&sm_interface, 0, sizeof(sm_interface));
-    sm_interface.m_getNumFaces          = mikk_get_num_faces;
+    sm_interface.m_getNumFaces = mikk_get_num_faces;
     sm_interface.m_getNumVerticesOfFace = mikk_get_num_verts_of_face;
-    sm_interface.m_getPosition          = mikk_get_position;
-    sm_interface.m_getTexCoord          = mikk_get_texture_coordinate;
-    sm_interface.m_getNormal            = mikk_get_normal;
-    sm_interface.m_setTSpaceBasic       = mikk_set_tangent_space;
+    sm_interface.m_getPosition = mikk_get_position;
+    sm_interface.m_getTexCoord = mikk_get_texture_coordinate;
+    sm_interface.m_getNormal = mikk_get_normal;
+    sm_interface.m_setTSpaceBasic = mikk_set_tangent_space;
     /* Setup context. */
     SMikkTSpaceContext context;
     memset(&context, 0, sizeof(context));
-    context.m_pUserData  = &userdata;
+    context.m_pUserData = &userdata;
     context.m_pInterface = &sm_interface;
     /* Compute tangents. */
     genTangSpaceDefault(&context);

--- a/plugin/hdCycles/volume.cpp
+++ b/plugin/hdCycles/volume.cpp
@@ -65,7 +65,7 @@ HdCyclesVolume::HdCyclesVolume(SdfPath const& id, SdfPath const& instancerId, Hd
     , m_renderDelegate(a_renderDelegate)
 {
     static const HdCyclesConfig& config = HdCyclesConfig::GetInstance();
-    m_useMotionBlur                     = config.enable_motion_blur.eval(m_useMotionBlur, true);
+    m_useMotionBlur = config.enable_motion_blur.eval(m_useMotionBlur, true);
 
     m_cyclesObject = _CreateObject();
     m_renderDelegate->GetCyclesRenderParam()->AddObjectSafe(m_cyclesObject);
@@ -111,7 +111,7 @@ HdCyclesVolume::_CreateObject()
     // Create container object
     ccl::Object* object = new ccl::Object();
 
-    object->visibility     = ccl::PATH_RAY_ALL_VISIBILITY;
+    object->visibility = ccl::PATH_RAY_ALL_VISIBILITY;
     object->velocity_scale = 1.0f;
     return object;
 }
@@ -122,8 +122,8 @@ HdCyclesVolume::_CreateVolume()
     // Create container object
     ccl::Mesh* volume = new ccl::Mesh();
 
-    volume->volume_clipping     = 0.001f;
-    volume->volume_step_size    = 0.0f;
+    volume->volume_clipping = 0.001f;
+    volume->volume_step_size = 0.0f;
     volume->volume_object_space = true;
 
     return volume;
@@ -149,7 +149,7 @@ HdCyclesVolume::_PopulateVolume(const SdfPath& id, HdSceneDelegate* delegate, cc
 
         if (vv.IsHolding<SdfAssetPath>()) {
             const auto& assetPath = vv.UncheckedGet<SdfAssetPath>();
-            auto path             = assetPath.GetResolvedPath();
+            auto path = assetPath.GetResolvedPath();
             if (path.empty()) {
                 path = assetPath.GetAssetPath();
             }
@@ -158,7 +158,7 @@ HdCyclesVolume::_PopulateVolume(const SdfPath& id, HdSceneDelegate* delegate, cc
             if (std::find(fields.begin(), fields.end(), field.fieldName) == fields.end()) {
                 fields.push_back(field.fieldName);
 
-                ccl::ustring name     = ccl::ustring(field.fieldName.GetString());
+                ccl::ustring name = ccl::ustring(field.fieldName.GetString());
                 ccl::ustring filepath = ccl::ustring(path);
 
                 ccl::AttributeStandard std = ccl::ATTR_STD_NONE;
@@ -200,7 +200,7 @@ HdCyclesVolume::_UpdateGrids()
         for (ccl::Attribute& attr : m_cyclesVolume->attributes.attributes) {
             if (attr.element == ccl::ATTR_ELEMENT_VOXEL) {
                 ccl::ImageHandle& handle = attr.data_voxel();
-                auto* loader             = static_cast<HdCyclesVolumeLoader*>(handle.vdb_loader());
+                auto* loader = static_cast<HdCyclesVolumeLoader*>(handle.vdb_loader());
 
                 if (loader) {
                     loader->UpdateGrid();
@@ -272,7 +272,7 @@ HdCyclesVolume::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam,
     if (*dirtyBits & HdChangeTracker::DirtyMaterialId) {
         if (m_cyclesVolume) {
             // Add default shader
-            const SdfPath& materialId        = sceneDelegate->GetMaterialId(GetId());
+            const SdfPath& materialId = sceneDelegate->GetMaterialId(GetId());
             const HdCyclesMaterial* material = static_cast<const HdCyclesMaterial*>(
                 sceneDelegate->GetRenderIndex().GetSprim(HdPrimTypeTokens->material, materialId));
 
@@ -283,7 +283,7 @@ HdCyclesVolume::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam,
                 m_usedShaders.push_back(scene->default_volume);
             }
             m_cyclesVolume->used_shaders = m_usedShaders;
-            update_volumes               = true;
+            update_volumes = true;
         }
     }
 

--- a/plugin/usdCycles/moduleDeps.cpp
+++ b/plugin/usdCycles/moduleDeps.cpp
@@ -17,23 +17,19 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-#include <pxr/pxr.h>
 #include <pxr/base/tf/registryManager.h>
 #include <pxr/base/tf/scriptModuleLoader.h>
 #include <pxr/base/tf/token.h>
+#include <pxr/pxr.h>
 
 #include <vector>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-TF_REGISTRY_FUNCTION(TfScriptModuleLoader) {
+TF_REGISTRY_FUNCTION(TfScriptModuleLoader)
+{
     // List of direct deps for this library
-    const std::vector<TfToken> reqs = {
-        TfToken("sdf"),
-        TfToken("tf"),
-        TfToken("usd"),
-        TfToken("vt")
-    };
+    const std::vector<TfToken> reqs = { TfToken("sdf"), TfToken("tf"), TfToken("usd"), TfToken("vt") };
     TfScriptModuleLoader::GetInstance().RegisterLibrary(TfToken("usdCycles"), TfToken("UsdCycles"), reqs);
 }
 


### PR DESCRIPTION
Turn off super annoying clang format option:

```
AlignConsecutiveAssignments: true 
```

This feature makes our PRs very difficult to read. For example #163 where there is a one line, that is the most important part of that PR. But it's gone because it's being hidden under formatting. 

Also, it gets better! When we have already setup alignment such as:

```
    m_cyclesLight->use_diffuse      = true;
    m_cyclesLight->use_glossy       = true;
    m_cyclesLight->use_transmission = true;
    m_cyclesLight->use_scatter      = true;
    m_cyclesLight->use_mis          = true;
    m_cyclesLight->is_portal        = false;
    m_cyclesLight->samples          = 1;
    m_cyclesLight->max_bounces      = 1024;
```

removing `m_cyclesLight->use_transmission = true;` from that list will cause entire code block to be reformatted. 

Burn the witch! :fire: 

