### PR TITLE
Disconnecting preview shader outputs when they override Cycles'

### DIFF
--- a/plugin/hdCycles/material.h
+++ b/plugin/hdCycles/material.h
@@ -28,6 +28,7 @@
 namespace ccl {
 class Object;
 class Shader;
+class ShaderNode;
 class ShaderGraph;
 }  // namespace ccl
 
@@ -124,6 +125,8 @@ protected:
     ccl::ShaderGraph* m_shaderGraph;
 
     HdCyclesRenderDelegate* m_renderDelegate;
+
+    void _FixPreviewShadersOutput(const std::vector<ccl::ShaderNode*>& preview_shaders);
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE


### PR DESCRIPTION
This patch checks the output nodes of the shader graph for preview materials. If preview and Cycles materials are present then the preview ones are disconnected, otherwise the shader graph is left untouched.

Do you foresee any problems with this patch? I tested different combinations and seems to produce what I would expect to see. 


Resolves internal ticket 6513