### PR TITLE
Added map_resolution schema for dome lights importance sampling

### DIFF
--- a/plugin/hdCycles/light.cpp
+++ b/plugin/hdCycles/light.cpp
@@ -199,6 +199,7 @@ HdCyclesLight::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam, 
     m_cyclesLight->is_portal = false;
     m_cyclesLight->samples = 1;
     m_cyclesLight->max_bounces = 1024;
+    m_cyclesLight->map_resolution = 0;
 
     // Always rebuild dome lights on transform change, the transform texture co-ordinate gets
     // optimised/folded out and we can't get it back to tweak...
@@ -588,8 +589,15 @@ HdCyclesLight::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam, 
     m_cyclesLight->samples = _HdCyclesGetLightParam<int>(id, sceneDelegate, usdCyclesTokens->cyclesLightSamples,
                                                          m_cyclesLight->samples);
 
+    if (m_renderDelegate->GetCyclesRenderParam()->IsSquareSamples()) {
+        m_cyclesLight->samples *= m_cyclesLight->samples;
+    }
+
     m_cyclesLight->max_bounces = _HdCyclesGetLightParam<int>(id, sceneDelegate, usdCyclesTokens->cyclesLightMax_bounces,
                                                              m_cyclesLight->max_bounces);
+
+    m_cyclesLight->map_resolution = _HdCyclesGetLightParam<int>(id, sceneDelegate, usdCyclesTokens->cyclesLightMap_resolution,
+                                                             m_cyclesLight->map_resolution);
 
     // TODO: Light is_enabled doesn't seem to have any effect
     if (*dirtyBits & HdChangeTracker::DirtyVisibility) {

--- a/plugin/hdCycles/renderParam.h
+++ b/plugin/hdCycles/renderParam.h
@@ -355,6 +355,14 @@ public:
 
     void UpdateShadersTag(ccl::vector<ccl::Shader*>& shaders);
 
+    /**
+     * @brief Return if square samples is enabled (for light samples to check against)
+     * 
+     * @return boolean
+     * 
+     */
+    bool IsSquareSamples() const { return m_useSquareSamples; }
+
 private:
     ccl::Session* m_cyclesSession;
     ccl::Scene* m_cyclesScene;

--- a/plugin/usdCycles/schema.usda
+++ b/plugin/usdCycles/schema.usda
@@ -959,6 +959,15 @@ class "CyclesLightSettingsAPI" (
         displayName = "Max Bounces"
         doc = "Maximum bounces of light ray"
     )
+
+    uniform int cycles:light:map_resolution = 0 (
+        customData = {
+            string apiName = "map_resolution"
+        }
+        displayGroup = "Light"
+        displayName = "Map Resolution"
+        doc = "Importance map size for dome light"
+    )
 }
 
 class "CyclesCameraSettingsAPI" (


### PR DESCRIPTION
- Fixed lights not being square-sampled when enabled in the render settings

This PR will require houdini_cycles to be updated to show the map_resolution schema