### PR TITLE
Cryptomatte metadata now hashes the exr layer name instead of source name

### DIFF
--- a/plugin/hdCycles/basisCurves.cpp
+++ b/plugin/hdCycles/basisCurves.cpp
@@ -451,6 +451,7 @@ HdCyclesBasisCurves::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderP
     m_cyclesObject->is_shadow_catcher = false;
     m_cyclesObject->pass_id = 0;
     m_cyclesObject->use_holdout = false;
+    m_cyclesObject->asset_name = "";
 
     if (*dirtyBits & HdChangeTracker::DirtyPoints) {
         HdCyclesPopulatePrimvarDescsPerInterpolation(sceneDelegate, id, &pdpi);
@@ -538,6 +539,12 @@ HdCyclesBasisCurves::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderP
         m_cyclesObject->use_holdout = _HdCyclesGetCurveParam<bool>(dirtyBits, id, this, sceneDelegate,
                                                                    usdCyclesTokens->primvarsCyclesObjectUse_holdout,
                                                                    m_cyclesObject->use_holdout);
+
+        std::string assetName = m_cyclesObject->asset_name.c_str();
+        assetName = _HdCyclesGetCurveParam<std::string>(dirtyBits, id, this, sceneDelegate,
+                                                        usdCyclesTokens->primvarsCyclesObjectAsset_name,
+                                                        assetName);
+        m_cyclesObject->asset_name = ccl::ustring(assetName);
 
         // Visibility
 

--- a/plugin/hdCycles/mesh.cpp
+++ b/plugin/hdCycles/mesh.cpp
@@ -1122,6 +1122,7 @@ HdCyclesMesh::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam, H
     m_cyclesObject->is_shadow_catcher = false;
     m_cyclesObject->pass_id = 0;
     m_cyclesObject->use_holdout = false;
+    m_cyclesObject->asset_name = "";
 
     for (auto& primvarDescsEntry : primvarDescsPerInterpolation) {
         for (auto& pv : primvarDescsEntry.second) {
@@ -1155,6 +1156,12 @@ HdCyclesMesh::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam, H
             m_cyclesObject->use_holdout = _HdCyclesGetMeshParam<bool>(pv, dirtyBits, id, this, sceneDelegate,
                                                                       usdCyclesTokens->primvarsCyclesObjectUse_holdout,
                                                                       m_cyclesObject->use_holdout);
+
+            std::string assetName = m_cyclesObject->asset_name.c_str();
+            assetName = _HdCyclesGetMeshParam<std::string>(pv, dirtyBits, id, this, sceneDelegate,
+                                                           usdCyclesTokens->primvarsCyclesObjectAsset_name,
+                                                           assetName);
+            m_cyclesObject->asset_name = ccl::ustring(assetName);
 
             // Visibility
 

--- a/plugin/usdCycles/schema.usda
+++ b/plugin/usdCycles/schema.usda
@@ -1346,6 +1346,15 @@ class "CyclesObjectSettingsAPI" (
         displayName = "Visibility Scatter"
         doc = "Should this object be visible by scatter rays"
     )
+
+    string primvars:cycles:object:asset_name = "" (
+        customData = {
+            string apiName = "object_asset_name"
+        }
+        displayGroup = "Object"
+        displayName = "Asset Name"
+        doc = "Asset name for cryptomatte asset pass"
+    )
 }
 
 class "CyclesMeshSettingsAPI" (


### PR DESCRIPTION
- Needed as the layer name can differ from the source name
- Added ambient occlusion, it was missing