### PR TITLE
override refineLevel by schema

### DIFF
--- a/plugin/hdCycles/mesh.cpp
+++ b/plugin/hdCycles/mesh.cpp
@@ -664,9 +664,7 @@ HdCyclesMesh::_PopulateTopology(HdSceneDelegate* sceneDelegate, const SdfPath& i
     topology.SetSubdivTags(GetSubdivTags(sceneDelegate));
 
     HdDisplayStyle display_style = sceneDelegate->GetDisplayStyle(id);
-    if (m_refineLevel > 0) {
-        display_style.refineLevel = m_refineLevel;
-    }
+    display_style.refineLevel = m_refineLevel;
 
     // Refiner holds pointer to topology therefore refiner can't outlive the topology
     m_topology = std::make_shared<HdBbMeshTopology>(id, topology, display_style.refineLevel);


### PR DESCRIPTION
Override refine level from the value that comes from the schema. That turns off control through complexity but allows us explicit control over the subdivision.