### PR TITLE
Handling crop render settings (dataWindowNDC)

### DIFF
--- a/plugin/hdCycles/renderBuffer.cpp
+++ b/plugin/hdCycles/renderBuffer.cpp
@@ -214,8 +214,7 @@ HdCyclesRenderBuffer::Finalize(HdRenderParam* renderParam)
 
 void
 HdCyclesRenderBuffer::BlitTile(HdFormat format, unsigned int x, unsigned int y, int unsigned width, unsigned int height,
-                               float width_data, float height_data,
-                               int offset, int stride, uint8_t const* data)
+                               float width_data, float height_data, int offset, int stride, uint8_t const* data)
 {
     // TODO: BlitTile shouldnt be called but it is...
     if (m_width <= 0) {
@@ -230,7 +229,6 @@ HdCyclesRenderBuffer::BlitTile(HdFormat format, unsigned int x, unsigned int y, 
 
     size_t pixelSize = HdDataSizeOfFormat(format);
 
-    // printf("src tile %d %d - %d %d | %d %d\n", x, y, width, height, width_data, height_data);
     const float x_scale_dst = (float)m_width / width_data;
     const float y_scale_dst = (float)m_height / height_data;
     const unsigned int x_dst = round(x_scale_dst * x);

--- a/plugin/hdCycles/renderBuffer.cpp
+++ b/plugin/hdCycles/renderBuffer.cpp
@@ -202,7 +202,7 @@ HdCyclesRenderBuffer::Clear()
     std::lock_guard<std::mutex> lock { m_mutex };
 
     size_t pixelSize = HdDataSizeOfFormat(m_format);
-    memset(&m_buffer[0], 0, m_buffer.size() * pixelSize);
+    memset(&m_buffer[0], 0, m_buffer.size());
 }
 
 void

--- a/plugin/hdCycles/renderBuffer.h
+++ b/plugin/hdCycles/renderBuffer.h
@@ -139,8 +139,8 @@ public:
      * @param stride Stride of pixel
      * @param data Pointer to data
      */
-    void BlitTile(HdFormat format, unsigned int x, unsigned int y, unsigned int width, unsigned int height, float width_data, float height_data,
-        int offset, int stride, uint8_t const* data);
+    void BlitTile(HdFormat format, unsigned int x, unsigned int y, unsigned int width, unsigned int height,
+                  float width_data, float height_data, int offset, int stride, uint8_t const* data);
 
 protected:
     /**

--- a/plugin/hdCycles/renderBuffer.h
+++ b/plugin/hdCycles/renderBuffer.h
@@ -139,8 +139,8 @@ public:
      * @param stride Stride of pixel
      * @param data Pointer to data
      */
-    void BlitTile(HdFormat format, unsigned int x, unsigned int y, unsigned int width, unsigned int height, int offset,
-                  int stride, uint8_t const* data);
+    void BlitTile(HdFormat format, unsigned int x, unsigned int y, unsigned int width, unsigned int height, float width_data, float height_data,
+        int offset, int stride, uint8_t const* data);
 
 protected:
     /**

--- a/plugin/hdCycles/renderParam.cpp
+++ b/plugin/hdCycles/renderParam.cpp
@@ -1577,9 +1577,7 @@ HdCyclesRenderParam::_WriteRenderTile(ccl::RenderTile& rtile)
             const float width_data_src = m_renderRect[2];
             const float height_data_src = m_renderRect[3];
 
-            rb->BlitTile(cyclesAov.format, x_src, y_src, rtile.w, rtile.h,
-                         width_data_src, height_data_src,
-                         0, rtile.w,
+            rb->BlitTile(cyclesAov.format, x_src, y_src, rtile.w, rtile.h, width_data_src, height_data_src, 0, rtile.w,
                          reinterpret_cast<uint8_t*>(tileData.data()));
         }
     }
@@ -1602,9 +1600,8 @@ HdCyclesRenderParam::_CreateScene()
     m_resolutionImage = GfVec2i(0, 0);
     m_resolutionDisplay = GfVec2i(config.render_width.value, config.render_height.value);
 
-    m_renderRect = GfVec4f(0.f, 0.f,
-        static_cast<float>(config.render_width.value),
-        static_cast<float>(config.render_height.value));
+    m_renderRect = GfVec4f(0.f, 0.f, static_cast<float>(config.render_width.value),
+                           static_cast<float>(config.render_height.value));
 
     m_cyclesScene->camera->width = m_resolutionDisplay[0];
     m_cyclesScene->camera->height = m_resolutionDisplay[1];
@@ -2420,7 +2417,6 @@ HdCyclesRenderParam::RemoveAovBinding(HdRenderBuffer* rb)
 void
 HdCyclesRenderParam::BlitFromCyclesPass(const HdRenderPassAovBinding& aov, int w, int h, int samples)
 {
-
     if (samples < 0) {
         return;
     }

--- a/plugin/hdCycles/renderParam.cpp
+++ b/plugin/hdCycles/renderParam.cpp
@@ -1827,6 +1827,9 @@ HdCyclesRenderParam::SetViewport(int w, int h)
     m_bufferParams.width = (int)(m_dataWindowNDC[2] * (float)m_width) - m_bufferParams.full_x;
     m_bufferParams.height = (int)(m_dataWindowNDC[3] * (float)m_height) - m_bufferParams.full_y;
 
+    m_bufferParams.width = ::std::max(m_bufferParams.width, 1);
+    m_bufferParams.height = ::std::max(m_bufferParams.height, 1);
+
     m_cyclesScene->camera->width = m_width;
     m_cyclesScene->camera->height = m_height;
     m_cyclesScene->camera->compute_auto_viewplane();

--- a/plugin/hdCycles/renderParam.h
+++ b/plugin/hdCycles/renderParam.h
@@ -306,9 +306,10 @@ private:
 
     bool m_aovBindingsNeedValidation;
 
-    int m_width;
-    int m_height;
     GfVec4f m_dataWindowNDC;
+    GfVec2i m_resolutionImage;
+    GfVec2i m_resolutionDisplay;
+    bool m_resolutionAuthored;
 
     bool m_objectsUpdated;
     bool m_geometryUpdated;

--- a/plugin/hdCycles/renderParam.h
+++ b/plugin/hdCycles/renderParam.h
@@ -310,6 +310,7 @@ private:
     GfVec2i m_resolutionImage;
     GfVec2i m_resolutionDisplay;
     bool m_resolutionAuthored;
+    GfVec4f m_renderRect;  // In pixels
 
     bool m_objectsUpdated;
     bool m_geometryUpdated;

--- a/plugin/hdCycles/renderParam.h
+++ b/plugin/hdCycles/renderParam.h
@@ -308,6 +308,7 @@ private:
 
     int m_width;
     int m_height;
+    GfVec4f m_dataWindowNDC;
 
     bool m_objectsUpdated;
     bool m_geometryUpdated;


### PR DESCRIPTION
Uses the dataWindowNDC attribute as cropping region for coreBlackbird.

It requires this [coreBlackbird PR](https://github.com/tangent-opensource/coreBlackbird/pull/58)

![Picture](https://user-images.githubusercontent.com/2072636/119688419-f7728400-be15-11eb-9540-633fc85ca6e9.png)
