### PR TITLE
Mesh motion normals

### DIFF
--- a/plugin/hdCycles/basisCurves.cpp
+++ b/plugin/hdCycles/basisCurves.cpp
@@ -200,7 +200,7 @@ HdCyclesBasisCurves::_PopulateMotion(HdSceneDelegate* sceneDelegate, const SdfPa
             continue;
 
         VtVec3fArray pp;
-        pp = values.data()[i].Get<VtVec3fArray>();
+        pp = motion_samples.values.data()[i].Get<VtVec3fArray>();
 
         for (size_t j = 0; j < m_points.size(); ++j, ++mP) {
             *mP = vec3f_to_float3(pp[j]);

--- a/plugin/hdCycles/mesh.cpp
+++ b/plugin/hdCycles/mesh.cpp
@@ -712,18 +712,7 @@ HdCyclesMesh::_PopulateMotionAttributeVec3f(HdSceneDelegate* sceneDelegate, cons
         if (times[i] == 0.0f)  // todo: more flexible check?
             continue;
 
-        VtValue refined_value;
-        if (interpolation_refine == HdInterpolationVertex) {
-            refined_value = refiner->RefineVertexData(token, role, values[i]);
-        } else if (interpolation_refine == HdInterpolationFaceVarying) {
-            refined_value = refiner->RefineFaceVaryingData(token, role, values[i]);
-        } else if (interpolation_refine == HdInterpolationUniform) {
-            refined_value = refiner->RefineUniformData(token, role, values[i]);
-        } else {
-            TF_WARN("Trying to populate motion attribute %s with unsupported interpolation", token.GetText());
-            return;
-        }
-
+        VtValue refined_value = refiner->Refine(token, role, values[i], interpolation_refine);
         if (!refined_value.IsHolding<VtVec3fArray>()) {
             TF_WARN("Cannot fill in motion step %d for: %s\n", static_cast<int>(i), id.GetText());
             continue;

--- a/plugin/hdCycles/mesh.cpp
+++ b/plugin/hdCycles/mesh.cpp
@@ -512,7 +512,6 @@ HdCyclesMesh::_PopulateNormals(HdSceneDelegate* sceneDelegate, const SdfPath& id
             normal_data[i] = vec3f_to_float3(refined_normals[i]);
         }
 #else
-
         ccl::Attribute* normal_attr = attributes.add(ccl::ATTR_STD_CORNER_NORMAL);
         ccl::float3* normal_data = normal_attr->data_float3();
 
@@ -1456,7 +1455,6 @@ HdCyclesMesh::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam, H
             }
         }
     }
-
 
     _FinishMesh(scene);
     _UpdateObject(scene, param, dirtyBits, topologyIsDirty);

--- a/plugin/hdCycles/mesh.h
+++ b/plugin/hdCycles/mesh.h
@@ -206,13 +206,10 @@ private:
      */
 
     void _PopulateMotion(HdSceneDelegate* sceneDelegate, const SdfPath& id);
-    bool _PopulateMotionAttributeVec3f(HdSceneDelegate* sceneDelegate, 
-                                  const SdfPath& id,
-                                  const TfToken& token,
-                                  const TfToken& role,
-                                  const HdInterpolation& interpolation,
-                                  int cycles_motion_attribute,
-                                  size_t n_expected_samples);
+    void _PopulateMotionAttributeVec3f(HdSceneDelegate* sceneDelegate, const SdfPath& id, const TfToken& token,
+                                       const TfToken& role, const HdInterpolation& interpolation_refine,
+                                       const HdInterpolation& interpolation, int cycles_motion_attribute,
+                                       size_t n_expected_samples);
 
     void _PopulateTopology(HdSceneDelegate* sceneDelegate, const SdfPath& id);
     void _PopulateVertices(HdSceneDelegate* sceneDelegate, const SdfPath& id, HdDirtyBits* dirtyBits);

--- a/plugin/hdCycles/mesh.h
+++ b/plugin/hdCycles/mesh.h
@@ -206,6 +206,13 @@ private:
      */
 
     void _PopulateMotion(HdSceneDelegate* sceneDelegate, const SdfPath& id);
+    bool _PopulateMotionAttributeVec3f(HdSceneDelegate* sceneDelegate, 
+                                  const SdfPath& id,
+                                  const TfToken& token,
+                                  const TfToken& role,
+                                  const HdInterpolation& interpolation,
+                                  int cycles_motion_attribute,
+                                  size_t n_expected_samples);
 
     void _PopulateTopology(HdSceneDelegate* sceneDelegate, const SdfPath& id);
     void _PopulateVertices(HdSceneDelegate* sceneDelegate, const SdfPath& id, HdDirtyBits* dirtyBits);


### PR DESCRIPTION
This patch populates custom motion normals for meshes. It requires this [Cycles PR](https://github.com/tangent-opensource/coreBlackbird/pull/60)

Testing it on assets with motion blur/subdivision and seems to behave as expected. Will do some further tests before merging, but it's ready to be reviewed.

@bareya Does the current solution suffice for now? Might not be super elegant but at least avoids duplicating too much code. We will eventually have to revisit the timesampled primvars