### PR TITLE
Bugfix/object removal performance

### DIFF
--- a/plugin/hdCycles/mesh.cpp
+++ b/plugin/hdCycles/mesh.cpp
@@ -71,21 +71,16 @@ HdCyclesMesh::~HdCyclesMesh()
 {
     ccl::thread_scoped_lock lock { m_renderDelegate->GetCyclesRenderParam()->GetCyclesScene()->mutex };
     if (m_cyclesMesh) {
-        m_renderDelegate->GetCyclesRenderParam()->RemoveGeometry(m_cyclesMesh);
+        m_renderDelegate->GetCyclesRenderParam()->RemoveGeometry(m_cyclesMesh, true);
         delete m_cyclesMesh;
     }
 
     if (m_cyclesObject) {
-        m_renderDelegate->GetCyclesRenderParam()->RemoveObject(m_cyclesObject);
         delete m_cyclesObject;
     }
 
-
     for (auto instance : m_cyclesInstances) {
-        if (instance) {
-            m_renderDelegate->GetCyclesRenderParam()->RemoveObject(instance);
-            delete instance;
-        }
+        delete instance;
     }
 }
 

--- a/plugin/hdCycles/mesh.cpp
+++ b/plugin/hdCycles/mesh.cpp
@@ -73,20 +73,21 @@ HdCyclesMesh::HdCyclesMesh(SdfPath const& id, SdfPath const& instancerId, HdCycl
 
 HdCyclesMesh::~HdCyclesMesh()
 {
+    ccl::thread_scoped_lock lock { m_renderDelegate->GetCyclesRenderParam()->GetCyclesScene()->mutex };
     if (m_cyclesMesh) {
-        m_renderDelegate->GetCyclesRenderParam()->RemoveGeometrySafe(m_cyclesMesh);
+        m_renderDelegate->GetCyclesRenderParam()->RemoveGeometry(m_cyclesMesh);
         delete m_cyclesMesh;
     }
 
     if (m_cyclesObject) {
-        m_renderDelegate->GetCyclesRenderParam()->RemoveObjectSafe(m_cyclesObject);
+        m_renderDelegate->GetCyclesRenderParam()->RemoveObject(m_cyclesObject);
         delete m_cyclesObject;
     }
 
 
     for (auto instance : m_cyclesInstances) {
         if (instance) {
-            m_renderDelegate->GetCyclesRenderParam()->RemoveObjectSafe(instance);
+            m_renderDelegate->GetCyclesRenderParam()->RemoveObject(instance);
             delete instance;
         }
     }

--- a/plugin/hdCycles/renderParam.cpp
+++ b/plugin/hdCycles/renderParam.cpp
@@ -1996,6 +1996,25 @@ HdCyclesRenderParam::RemoveLight(ccl::Light* light)
         Interrupt();
 }
 
+void
+HdCyclesRenderParam::RemoveInstancesOf(const ccl::Geometry* geometry)
+{
+    size_t num = m_cyclesScene->objects.size();
+
+    for (size_t i = 0; i < num; i++) {
+        if (geometry == m_cyclesScene->objects[i]->geometry) {
+            num--;
+            m_cyclesScene->objects[i] = m_cyclesScene->objects[num];
+            i--;
+        }
+    }
+
+    if (num != m_cyclesScene->objects.size()) {
+        m_cyclesScene->objects.resize(num);
+        m_objectsUpdated = true;
+        Interrupt();
+    }
+}
 
 void
 HdCyclesRenderParam::RemoveObject(ccl::Object* object)
@@ -2015,7 +2034,7 @@ HdCyclesRenderParam::RemoveObject(ccl::Object* object)
 }
 
 void
-HdCyclesRenderParam::RemoveGeometry(ccl::Geometry* geometry)
+HdCyclesRenderParam::RemoveGeometry(ccl::Geometry* geometry, bool removeObjects)
 {
     for (auto it = m_cyclesScene->geometry.begin(); it != m_cyclesScene->geometry.end();) {
         if (geometry == *it) {
@@ -2027,6 +2046,10 @@ HdCyclesRenderParam::RemoveGeometry(ccl::Geometry* geometry)
         } else {
             ++it;
         }
+    }
+
+    if (removeObjects) {
+        RemoveInstancesOf(geometry);
     }
 
     if (m_geometryUpdated)

--- a/plugin/hdCycles/renderParam.cpp
+++ b/plugin/hdCycles/renderParam.cpp
@@ -1857,14 +1857,13 @@ HdCyclesRenderParam::RemoveLight(ccl::Light* light)
 void
 HdCyclesRenderParam::RemoveObject(ccl::Object* object)
 {
-    for (auto it = m_cyclesScene->objects.begin(); it != m_cyclesScene->objects.end();) {
-        if (object == *it) {
-            it = m_cyclesScene->objects.erase(it);
+    for (auto &it : m_cyclesScene->objects) {
+        if (object == it) {
+            it = *(m_cyclesScene->objects.end() - 1);
+            m_cyclesScene->objects.resize(m_cyclesScene->objects.size() - 1);
 
             m_objectsUpdated = true;
             break;
-        } else {
-            ++it;
         }
     }
 

--- a/plugin/hdCycles/renderParam.h
+++ b/plugin/hdCycles/renderParam.h
@@ -225,7 +225,8 @@ public:
     void RemoveShader(ccl::Shader* shader);
     void RemoveLight(ccl::Light* light);
     void RemoveObject(ccl::Object* object);
-    void RemoveGeometry(ccl::Geometry* geometry);
+    void RemoveGeometry(ccl::Geometry* geometry, bool removeInstances = false);
+    void RemoveInstancesOf(const ccl::Geometry* geometry);
 
     /* ====== Thread safe operations ====== */
 


### PR DESCRIPTION
This is a performance improvement that brings scenes that were previously unusuably slow to reasonable performance. In cases of hundreds of thousands of instances, exiting hdBlackbird would previously take 30min or longer, now it's down to about one minute.

This is not intended as a replacement for https://github.com/tangent-opensource/hdBlackbird/pull/161 but rather a quick fix until that one is ready.