### PR TITLE
Add Closure Volume Suport

### DIFF
--- a/plugin/hdCycles/material.cpp
+++ b/plugin/hdCycles/material.cpp
@@ -553,10 +553,33 @@ GetMaterialNetwork(TfToken const& terminal, HdSceneDelegate* delegate, HdMateria
                                 graph->connect(cycles_node->output("BSDF"), graph->output()->input("Surface"));
 
                             } else if (cycles_node->output("Closure") != NULL) {
-                                graph->connect(cycles_node->output("Closure"), graph->output()->input("Surface"));
+                                bool has_volume_connection = false;
+
+                                for (const HdMaterialRelationship& matRel : net.second.relationships) {
+                                    ccl::ShaderNode* tonode = conversionMap[matRel.outputId].second;
+                                    ccl::ShaderNode* fromnode = conversionMap[matRel.inputId].second;
+
+                                    // Skip invalid connections.
+                                    if (fromnode == nullptr || tonode == nullptr) {
+                                        continue;
+                                    }
+
+                                    if (tonode->output("Volume") != NULL || fromnode->output("Volume") != NULL) {
+                                        has_volume_connection = true;
+                                        break;
+                                    }
+                                }
+
+                                if (has_volume_connection) {
+                                    graph->connect(cycles_node->output("Closure"), graph->output()->input("Volume"));
+                                } else {
+                                    graph->connect(cycles_node->output("Closure"), graph->output()->input("Surface"));
+                                }
 
                             } else if (cycles_node->output("Emission") != NULL) {
                                 graph->connect(cycles_node->output("Emission"), graph->output()->input("Surface"));
+                            } else if (cycles_node->output("Volume") != NULL) {
+                                graph->connect(cycles_node->output("Volume"), graph->output()->input("Volume"));
                             }
                         }
                         if (terminal == HdCyclesMaterialTerminalTokens->displacement) {


### PR DESCRIPTION
This PR Checks for Volume connection to an Add Closure node and connects the output to "Volume" input if there is one. This is required for being able to connect volumetric nodes (scatter, absorption, etc.) to Add Closure and Mix Closure nodes. 

This PR depends on houdiniBlackbird PR 9 to be merged.  