### PR TITLE
Point transparency changes

### DIFF
--- a/plugin/hdCycles/config.cpp
+++ b/plugin/hdCycles/config.cpp
@@ -129,7 +129,7 @@ HdCyclesConfig::HdCyclesConfig()
     start_resolution = HdCyclesEnvValue<int>("HD_CYCLES_START_RESOLUTION", 8);
     shutter_motion_position = HdCyclesEnvValue<int>("HD_CYCLES_SHUTTER_MOTION_POSITION", 1);
 
-    default_point_style      = HdCyclesEnvValue<int>("HD_CYCLES_DEFAULT_POINT_STYLE", ccl::POINT_CLOUD_POINT_SPHERE);
+    default_point_style      = HdCyclesEnvValue<int>("HD_CYCLES_DEFAULT_POINT_STYLE", ccl::POINT_CLOUD_POINT_DISC);
     default_point_resolution = HdCyclesEnvValue<int>("HD_CYCLES_DEFAULT_POINT_RESOLUTION", 16);
 
     texture_use_cache = HdCyclesEnvValue<bool>("HD_BLACKBIRD_TEXTURE_USE_CACHE", false);

--- a/plugin/hdCycles/utils.cpp
+++ b/plugin/hdCycles/utils.cpp
@@ -139,7 +139,6 @@ HdCyclesCreateDefaultShader()
 
     ccl::ShaderNode* out = shader->graph->output();
     shader->graph->connect(vc->output("Color"), bsdf->input("Base Color"));
-    shader->graph->connect(vc->output("Alpha"), bsdf->input("Alpha"));
     shader->graph->connect(bsdf->output("BSDF"), out->input("Surface"));
 
     return shader;


### PR DESCRIPTION
Changes
- Glue code for this [core patch](https://github.com/tangent-opensource/coreBlackbird/pull/72)
- Changed the default point style to Sphere from Disc. This is consistent with the Houdini schema.
- Disconnected alpha socket in the render param default shader. This shader is only being used by point clouds, I will rename the shader accordingly to make it clear it's meant for point clouds.

**Note** Opacities should be passed to the pointcloud through their own socket. I am waiting to merge the core patch to 2.93