### PR TITLE
Wrap common settings under HdBbRPrim

### DIFF
--- a/plugin/hdCycles/CMakeLists.txt
+++ b/plugin/hdCycles/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(MikktSpace::MikktSpace ALIAS MikktSpace)
 
 add_library(hdCycles SHARED
         api.h
+        rprim.h
         basisCurves.cpp
         basisCurves.h
         camera.cpp

--- a/plugin/hdCycles/basisCurves.cpp
+++ b/plugin/hdCycles/basisCurves.cpp
@@ -81,17 +81,9 @@ TF_DEFINE_PRIVATE_TOKENS(_tokens,
 
 HdCyclesBasisCurves::HdCyclesBasisCurves(SdfPath const& id, SdfPath const& instancerId,
                                          HdCyclesRenderDelegate* a_renderDelegate)
-    : HdBasisCurves(id, instancerId)
-    , m_visibilityFlags(ccl::PATH_RAY_ALL_VISIBILITY)
-    , m_visCamera(true)
-    , m_visDiffuse(true)
-    , m_visGlossy(true)
-    , m_visScatter(true)
-    , m_visShadow(true)
-    , m_visTransmission(true)
+    : HdBbRPrim<HdBasisCurves>(id, instancerId)
     , m_curveShape(ccl::CURVE_THICK)
     , m_curveResolution(5)
-    , m_cyclesObject(nullptr)
     , m_cyclesMesh(nullptr)
     , m_cyclesHair(nullptr)
     , m_cyclesGeometry(nullptr)
@@ -442,17 +434,6 @@ HdCyclesBasisCurves::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderP
     bool generate_new_curve = false;
     bool update_curve = false;
 
-    // Defaults
-    m_visCamera = m_visDiffuse = m_visGlossy = m_visScatter = m_visShadow = m_visTransmission = true;
-    m_motionBlur = true;
-    m_motionTransformSteps = 3;
-    m_motionDeformSteps = 3;
-    m_cyclesObject->is_shadow_catcher = false;
-    m_cyclesObject->pass_id = 0;
-    m_cyclesObject->use_holdout = false;
-    m_cyclesObject->asset_name = "";
-    m_cyclesObject->lightgroup = "";
-
     // initial values
     TfToken curveShape = usdCyclesTokens->ribbon;
     m_points.clear();
@@ -479,20 +460,11 @@ HdCyclesBasisCurves::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderP
     std::vector<HdBbPrimvar> primvars;
 
     if (*dirtyBits & HdChangeTracker::DirtyPrimvar) {
-        std::array<std::pair<HdInterpolation, HdPrimvarDescriptorVector>, 5> primvars_desc {
-            std::make_pair(HdInterpolationConstant, HdPrimvarDescriptorVector {}),
-            std::make_pair(HdInterpolationUniform, HdPrimvarDescriptorVector {}),
-            std::make_pair(HdInterpolationVertex, HdPrimvarDescriptorVector {}),
-            std::make_pair(HdInterpolationVarying, HdPrimvarDescriptorVector {}),
-            std::make_pair(HdInterpolationFaceVarying, HdPrimvarDescriptorVector {}),
-        };
-
-        for (auto& info : primvars_desc) {
-            info.second = sceneDelegate->GetPrimvarDescriptors(id, info.first);
-        }
+        HdPrimvarDescriptorMap primvarDescsPerInterpolation = GetPrimvarDescriptorMap(sceneDelegate);
+        GetObjectPrimvars(primvarDescsPerInterpolation, sceneDelegate, dirtyBits);
 
         //
-        for (auto& interpolation_description : primvars_desc) {
+        for (auto& interpolation_description : primvarDescsPerInterpolation) {
             for (const HdPrimvarDescriptor& description : interpolation_description.second) {
                 if (!HdChangeTracker::IsPrimvarDirty(*dirtyBits, id, description.name)) {
                     continue;
@@ -566,109 +538,6 @@ HdCyclesBasisCurves::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderP
                             update_curve = true;
                         }
                     }
-                    continue;
-                }
-
-                if (primvar_name == usdCyclesTokens->primvarsCyclesObjectAsset_name) {
-                    VtValue value = GetPrimvar(sceneDelegate, usdCyclesTokens->primvarsCyclesObjectAsset_name);
-                    if (value.IsHolding<std::string>()) {
-                        std::string assetName = value.Get<std::string>();
-                        m_cyclesObject->asset_name = ccl::ustring(assetName);
-                    }
-                    continue;
-                }
-
-                if (primvar_name == usdCyclesTokens->primvarsCyclesObjectLightgroup) {
-                    VtValue value = GetPrimvar(sceneDelegate, usdCyclesTokens->primvarsCyclesObjectLightgroup);
-                    if (value.IsHolding<std::string>()) {
-                        std::string lightGroup = value.Get<std::string>();
-                        m_cyclesObject->lightgroup = ccl::ustring(lightGroup);
-                    }
-                    continue;
-                }
-
-                if (primvar_name == usdCyclesTokens->primvarsCyclesObjectMblur) {
-                    VtValue value = GetPrimvar(sceneDelegate, usdCyclesTokens->primvarsCyclesObjectMblur);
-                    m_motionBlur = value.Get<bool>();
-                    continue;
-                }
-
-                if (primvar_name == usdCyclesTokens->primvarsCyclesObjectTransformSamples) {
-                    VtValue value = GetPrimvar(sceneDelegate, usdCyclesTokens->primvarsCyclesObjectTransformSamples);
-                    m_motionTransformSteps = value.Get<int>();
-                    continue;
-                }
-
-                if (primvar_name == usdCyclesTokens->primvarsCyclesObjectDeformSamples) {
-                    VtValue value = GetPrimvar(sceneDelegate, usdCyclesTokens->primvarsCyclesObjectDeformSamples);
-                    m_motionDeformSteps = value.Get<int>();
-                    continue;
-                }
-
-                if (primvar_name == usdCyclesTokens->primvarsCyclesObjectIs_shadow_catcher) {
-                    VtValue value = GetPrimvar(sceneDelegate, usdCyclesTokens->primvarsCyclesObjectIs_shadow_catcher);
-                    if (value.IsHolding<bool>())
-                        m_cyclesObject->is_shadow_catcher = value.Get<bool>();
-                    continue;
-                }
-
-                if (primvar_name == usdCyclesTokens->primvarsCyclesObjectPass_id) {
-                    VtValue value = GetPrimvar(sceneDelegate, usdCyclesTokens->primvarsCyclesObjectPass_id);
-                    if (value.IsHolding<bool>())
-                        m_cyclesObject->pass_id = value.Get<bool>();
-                    continue;
-                }
-
-                if (primvar_name == usdCyclesTokens->primvarsCyclesObjectUse_holdout) {
-                    VtValue value = GetPrimvar(sceneDelegate, usdCyclesTokens->primvarsCyclesObjectUse_holdout);
-                    if (value.IsHolding<bool>())
-                        m_cyclesObject->use_holdout = value.Get<bool>();
-                    continue;
-                }
-
-                //
-                // Visibility schema
-                //
-                if (primvar_name == usdCyclesTokens->primvarsCyclesObjectVisibilityCamera) {
-                    VtValue value = GetPrimvar(sceneDelegate, usdCyclesTokens->primvarsCyclesObjectVisibilityCamera);
-                    if (value.IsHolding<bool>())
-                        m_visCamera = value.Get<bool>();
-                    continue;
-                }
-
-                if (primvar_name == usdCyclesTokens->primvarsCyclesObjectVisibilityDiffuse) {
-                    VtValue value = GetPrimvar(sceneDelegate, usdCyclesTokens->primvarsCyclesObjectVisibilityDiffuse);
-                    if (value.IsHolding<bool>())
-                        m_visDiffuse = value.Get<bool>();
-                    continue;
-                }
-
-                if (primvar_name == usdCyclesTokens->primvarsCyclesObjectVisibilityGlossy) {
-                    VtValue value = GetPrimvar(sceneDelegate, usdCyclesTokens->primvarsCyclesObjectVisibilityGlossy);
-                    if (value.IsHolding<bool>())
-                        m_visGlossy = value.Get<bool>();
-                    continue;
-                }
-
-                if (primvar_name == usdCyclesTokens->primvarsCyclesObjectVisibilityScatter) {
-                    VtValue value = GetPrimvar(sceneDelegate, usdCyclesTokens->primvarsCyclesObjectVisibilityScatter);
-                    if (value.IsHolding<bool>())
-                        m_visScatter = value.Get<bool>();
-                    continue;
-                }
-
-                if (primvar_name == usdCyclesTokens->primvarsCyclesObjectVisibilityShadow) {
-                    VtValue value = GetPrimvar(sceneDelegate, usdCyclesTokens->primvarsCyclesObjectVisibilityShadow);
-                    if (value.IsHolding<bool>())
-                        m_visShadow = value.Get<bool>();
-                    continue;
-                }
-
-                if (primvar_name == usdCyclesTokens->primvarsCyclesObjectVisibilityTransmission) {
-                    VtValue value = GetPrimvar(sceneDelegate,
-                                               usdCyclesTokens->primvarsCyclesObjectVisibilityTransmission);
-                    if (value.IsHolding<bool>())
-                        m_visTransmission = value.Get<bool>();
                     continue;
                 }
             }
@@ -783,13 +652,6 @@ HdCyclesBasisCurves::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderP
 
     if (generate_new_curve || update_curve) {
         m_cyclesHair->curve_shape = m_curveShape;
-
-        m_visibilityFlags |= m_visCamera ? ccl::PATH_RAY_CAMERA : 0;
-        m_visibilityFlags |= m_visDiffuse ? ccl::PATH_RAY_DIFFUSE : 0;
-        m_visibilityFlags |= m_visGlossy ? ccl::PATH_RAY_GLOSSY : 0;
-        m_visibilityFlags |= m_visScatter ? ccl::PATH_RAY_VOLUME_SCATTER : 0;
-        m_visibilityFlags |= m_visShadow ? ccl::PATH_RAY_SHADOW : 0;
-        m_visibilityFlags |= m_visTransmission ? ccl::PATH_RAY_TRANSMIT : 0;
 
         m_cyclesObject->visibility = m_visibilityFlags;
         if (!_sharedData.visible)

--- a/plugin/hdCycles/basisCurves.h
+++ b/plugin/hdCycles/basisCurves.h
@@ -27,6 +27,7 @@
 #include "objectSource.h"
 #include "renderDelegate.h"
 #include "utils.h"
+#include "rprim.h"
 
 #include <util/util_transform.h>
 
@@ -53,7 +54,7 @@ class HdCyclesRenderDelegate;
  * @brief Cycles Basis Curve Rprim mapped to Cycles Basis Curve
  * 
  */
-class HdCyclesBasisCurves final : public HdBasisCurves {
+class HdCyclesBasisCurves final : public HdBbRPrim<HdBasisCurves> {
 public:
     /**
      * @brief Construct a new HdCycles Basis Curve object
@@ -157,18 +158,7 @@ protected:
     VtIntArray m_indices;
     GfMatrix4f m_transform;
 
-    bool m_motionBlur;
-    int m_motionTransformSteps;
-    int m_motionDeformSteps;
-
     unsigned int m_visibilityFlags;
-
-    bool m_visCamera;
-    bool m_visDiffuse;
-    bool m_visGlossy;
-    bool m_visScatter;
-    bool m_visShadow;
-    bool m_visTransmission;
 
     ccl::CurveShapeType m_curveShape;
     int m_curveResolution;
@@ -201,7 +191,6 @@ private:
      */
     void _CreateCurves(ccl::Scene* a_scene);
 
-    ccl::Object* m_cyclesObject;
     ccl::Mesh* m_cyclesMesh;
     ccl::Hair* m_cyclesHair;
     ccl::Geometry* m_cyclesGeometry;

--- a/plugin/hdCycles/mesh.cpp
+++ b/plugin/hdCycles/mesh.cpp
@@ -54,12 +54,6 @@ HdCyclesMesh::HdCyclesMesh(SdfPath const& id, SdfPath const& instancerId, HdCycl
     : HdBbRPrim<HdMesh>(id, instancerId)
     , m_cyclesMesh(nullptr)
     , m_velocityScale(1.0f)
-    , m_visCamera(true)
-    , m_visDiffuse(true)
-    , m_visGlossy(true)
-    , m_visScatter(true)
-    , m_visShadow(true)
-    , m_visTransmission(true)
     , m_renderDelegate(a_renderDelegate)
 {
     _InitializeNewCyclesMesh();

--- a/plugin/hdCycles/mesh.cpp
+++ b/plugin/hdCycles/mesh.cpp
@@ -1358,17 +1358,7 @@ HdCyclesMesh::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam, H
 void
 HdCyclesMesh::_UpdateObject(ccl::Scene* scene, HdCyclesRenderParam* param, HdDirtyBits* dirtyBits, bool rebuildBvh)
 {
-    m_cyclesObject->visibility = _sharedData.visible ? m_visibilityFlags : 0;
-    m_cyclesMesh->tag_update(scene, rebuildBvh);
-    m_cyclesObject->tag_update(scene);
-
-    // Mark visibility clean. When sync method is called object might be invisible. At that point we do not
-    // need to trigger the topology and data generation. It can be postponed until visibility becomes on.
-    // We need to manually mark visibility clean, but other flags remain dirty.
-    if (!_sharedData.visible) {
-        *dirtyBits &= ~HdChangeTracker::DirtyVisibility;
-    }
-
+    UpdateObject(scene, dirtyBits, rebuildBvh);
     param->Interrupt();
 }
 

--- a/plugin/hdCycles/mesh.h
+++ b/plugin/hdCycles/mesh.h
@@ -25,6 +25,7 @@
 #include "hdcycles.h"
 #include "meshRefiner.h"
 #include "objectSource.h"
+#include "rprim.h"
 
 #include <util/util_transform.h>
 
@@ -55,7 +56,7 @@ class HdCyclesRenderParam;
  * @brief HdCycles Mesh Rprim mapped to Cycles mesh
  * 
  */
-class HdCyclesMesh final : public HdMesh {
+class HdCyclesMesh final : public HdBbRPrim<HdMesh> {
 public:
     HF_MALLOC_TAG_NEW("new HdCyclesMesh")
 
@@ -240,7 +241,6 @@ private:
     HdCyclesObjectSourceSharedPtr m_object_source;
 
     ccl::Mesh* m_cyclesMesh;
-    ccl::Object* m_cyclesObject;
     std::vector<ccl::Object> m_cyclesInstances;
 
     ccl::Shader* m_object_display_color_shader;
@@ -252,12 +252,6 @@ private:
     std::shared_ptr<HdBbMeshTopology> m_topology;
 
     float m_velocityScale;
-
-    bool m_motionBlur;
-    int m_motionTransformSteps;
-    int m_motionDeformSteps;
-
-    unsigned int m_visibilityFlags;
 
     bool m_visCamera;
     bool m_visDiffuse;

--- a/plugin/hdCycles/mesh.h
+++ b/plugin/hdCycles/mesh.h
@@ -253,13 +253,6 @@ private:
 
     float m_velocityScale;
 
-    bool m_visCamera;
-    bool m_visDiffuse;
-    bool m_visGlossy;
-    bool m_visScatter;
-    bool m_visShadow;
-    bool m_visTransmission;
-
     std::vector<ccl::ustring> m_texture_names;
     VtFloat3Array m_limit_us;
     VtFloat3Array m_limit_vs;

--- a/plugin/hdCycles/points.cpp
+++ b/plugin/hdCycles/points.cpp
@@ -44,12 +44,9 @@
 PXR_NAMESPACE_OPEN_SCOPE
 
 HdCyclesPoints::HdCyclesPoints(SdfPath const& id, SdfPath const& instancerId, HdCyclesRenderDelegate* a_renderDelegate)
-    : HdPoints(id, instancerId)
+    : HdBbRPrim(id, instancerId)
     , m_cyclesPointCloud(nullptr)
-    , m_cyclesObject(nullptr)
-    , m_visibilityFlags(ccl::PATH_RAY_ALL_VISIBILITY)
     , m_point_display_color_shader(nullptr)
-    , m_motionBlur(false)
     , m_renderDelegate(a_renderDelegate)
 {
     static const HdCyclesConfig& config = HdCyclesConfig::GetInstance();
@@ -127,106 +124,8 @@ HdCyclesPoints::_ReadObjectFlags(HdSceneDelegate* sceneDelegate, const SdfPath& 
 {
     assert(m_cyclesObject);
 
-    m_motionBlur = true;
-    m_motionTransformSteps = 3;
-    m_motionDeformSteps = 3;
-
-    std::map<HdInterpolation, HdPrimvarDescriptorVector> primvarDescsPerInterpolation = {
-        { HdInterpolationFaceVarying, sceneDelegate->GetPrimvarDescriptors(id, HdInterpolationFaceVarying) },
-        { HdInterpolationVertex, sceneDelegate->GetPrimvarDescriptors(id, HdInterpolationVertex) },
-        { HdInterpolationConstant, sceneDelegate->GetPrimvarDescriptors(id, HdInterpolationConstant) },
-        { HdInterpolationUniform, sceneDelegate->GetPrimvarDescriptors(id, HdInterpolationUniform) },
-    };
-
-    for (auto& primvarDescsEntry : primvarDescsPerInterpolation) {
-        for (auto& pv : primvarDescsEntry.second) {
-            if (!HdChangeTracker::IsPrimvarDirty(*dirtyBits, id, pv.name)) {
-                continue;
-            }
-
-            const std::string primvar_name = std::string { "primvars:" } + pv.name.GetString();
-
-            // motion blur settings
-
-            if (primvar_name == usdCyclesTokens->primvarsCyclesObjectMblur) {
-                VtValue value = GetPrimvar(sceneDelegate, usdCyclesTokens->primvarsCyclesObjectMblur);
-                m_motionBlur = value.Get<bool>();
-                continue;
-            }
-
-            if (primvar_name == usdCyclesTokens->primvarsCyclesObjectTransformSamples) {
-                VtValue value = GetPrimvar(sceneDelegate, usdCyclesTokens->primvarsCyclesObjectTransformSamples);
-                m_motionTransformSteps = value.Get<int>();
-                continue;
-            }
-
-            if (primvar_name == usdCyclesTokens->primvarsCyclesObjectDeformSamples) {
-                VtValue value = GetPrimvar(sceneDelegate, usdCyclesTokens->primvarsCyclesObjectDeformSamples);
-                m_motionDeformSteps = value.Get<int>();
-                continue;
-            }
-
-            // Object Generic
-
-            m_cyclesObject->is_shadow_catcher
-                = _HdCyclesGetPointsParam<bool>(pv, dirtyBits, id, this, sceneDelegate,
-                                                usdCyclesTokens->primvarsCyclesObjectIs_shadow_catcher,
-                                                m_cyclesObject->is_shadow_catcher);
-
-            m_cyclesObject->pass_id = _HdCyclesGetPointsParam<bool>(pv, dirtyBits, id, this, sceneDelegate,
-                                                                    usdCyclesTokens->primvarsCyclesObjectPass_id,
-                                                                    m_cyclesObject->pass_id);
-
-            m_cyclesObject->use_holdout = _HdCyclesGetPointsParam<bool>(pv, dirtyBits, id, this, sceneDelegate,
-                                                                        usdCyclesTokens->primvarsCyclesObjectUse_holdout,
-                                                                        m_cyclesObject->use_holdout);
-
-            // Visibility
-            m_visibilityFlags = 0;
-
-            bool bit = true;
-            _HdCyclesGetPointsParam<bool>(pv, dirtyBits, id, this, sceneDelegate,
-                                          usdCyclesTokens->primvarsCyclesObjectVisibilityCamera, bit);
-            if (bit) {
-                m_visibilityFlags |= ccl::PATH_RAY_CAMERA;
-            }
-
-            bit = true;
-            _HdCyclesGetPointsParam<bool>(pv, dirtyBits, id, this, sceneDelegate,
-                                          usdCyclesTokens->primvarsCyclesObjectVisibilityDiffuse, bit);
-            if (bit) {
-                m_visibilityFlags |= ccl::PATH_RAY_DIFFUSE;
-            }
-
-            bit = true;
-            _HdCyclesGetPointsParam<bool>(pv, dirtyBits, id, this, sceneDelegate,
-                                          usdCyclesTokens->primvarsCyclesObjectVisibilityGlossy, bit);
-            if (bit) {
-                m_visibilityFlags |= ccl::PATH_RAY_GLOSSY;
-            }
-
-            bit = true;
-            _HdCyclesGetPointsParam<bool>(pv, dirtyBits, id, this, sceneDelegate,
-                                          usdCyclesTokens->primvarsCyclesObjectVisibilityScatter, bit);
-            if (bit) {
-                m_visibilityFlags |= ccl::PATH_RAY_VOLUME_SCATTER;
-            }
-
-            bit = true;
-            _HdCyclesGetPointsParam<bool>(pv, dirtyBits, id, this, sceneDelegate,
-                                          usdCyclesTokens->primvarsCyclesObjectVisibilityShadow, bit);
-            if (bit) {
-                m_visibilityFlags |= ccl::PATH_RAY_SHADOW;
-            }
-
-            bit = true;
-            _HdCyclesGetPointsParam<bool>(pv, dirtyBits, id, this, sceneDelegate,
-                                          usdCyclesTokens->primvarsCyclesObjectVisibilityTransmission, bit);
-            if (bit) {
-                m_visibilityFlags |= ccl::PATH_RAY_TRANSMIT;
-            }
-        }
-    }
+    HdPrimvarDescriptorMap primvarDescsPerInterpolation = GetPrimvarDescriptorMap(sceneDelegate);
+    GetObjectPrimvars(primvarDescsPerInterpolation, sceneDelegate, dirtyBits);
 }
 
 void

--- a/plugin/hdCycles/points.h
+++ b/plugin/hdCycles/points.h
@@ -24,6 +24,7 @@
 
 #include "hdcycles.h"
 #include "renderDelegate.h"
+#include "rprim.h"
 
 #include <util/util_transform.h>
 
@@ -47,7 +48,7 @@ class HdCyclesRenderDelegate;
  * @brief HdCycles Points Rprim mapped to Cycles point cloud or mesh instances
  * 
  */
-class HdCyclesPoints final : public HdPoints {
+class HdCyclesPoints final : public HdBbRPrim<HdPoints> {
 public:
     /**
      * @brief Construct a new HdCycles Point object
@@ -187,20 +188,13 @@ private:
     void _CheckIntegrity(HdCyclesRenderParam* param);
 
     ccl::PointCloud* m_cyclesPointCloud;
-    ccl::Object* m_cyclesObject;
 
     ccl::Shader* m_point_display_color_shader;
 
     int m_pointResolution;  // ?
 
-    unsigned int m_visibilityFlags;
-
     HdCyclesObjectSourceSharedPtr m_objectSource;
     HdCyclesRenderDelegate* m_renderDelegate;
-
-    bool m_motionBlur;
-    int m_motionTransformSteps;
-    int m_motionDeformSteps;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/plugin/hdCycles/rprim.h
+++ b/plugin/hdCycles/rprim.h
@@ -1,0 +1,211 @@
+//  Copyright 2021 Tangent Animation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+//  including without limitation, as related to merchantability and fitness
+//  for a particular purpose.
+//
+//  In no event shall any copyright holder be liable for any damages of any kind
+//  arising from the use of this software, whether in contract, tort or otherwise.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+
+#ifndef HDBLACKBIRD_RPRIM_H
+#define HDBLACKBIRD_RPRIM_H
+
+#include <usdCycles/tokens.h>
+
+#include <pxr/imaging/hd/rprim.h>
+
+#include <render/object.h>
+
+#include <map>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+template<typename T> class HdBbRPrim : public T {
+public:
+    static_assert(!std::is_base_of<T, HdRprim>::value, "HdBbRPrim must wrap HdRPrim class");
+
+    using HdPrimvarDescriptorMap = std::map<HdInterpolation, HdPrimvarDescriptorVector>;
+
+protected:
+    HdBbRPrim(SdfPath const& id, SdfPath const& instancerId)
+        : T { id, instancerId }
+        , m_cyclesObject { nullptr }
+        , m_visibilityFlags { ccl::PATH_RAY_ALL_VISIBILITY }
+        , m_motionBlur { true }
+        , m_motionTransformSteps { 3 }
+        , m_motionDeformSteps { 3 }
+    {
+    }
+
+    HdPrimvarDescriptorMap GetPrimvarDescriptorMap(HdSceneDelegate* sceneDelegate) const
+    {
+        SdfPath const& id = T::GetId();
+        return {
+            { HdInterpolationFaceVarying, sceneDelegate->GetPrimvarDescriptors(id, HdInterpolationFaceVarying) },
+            { HdInterpolationVertex, sceneDelegate->GetPrimvarDescriptors(id, HdInterpolationVertex) },
+            { HdInterpolationConstant, sceneDelegate->GetPrimvarDescriptors(id, HdInterpolationConstant) },
+            { HdInterpolationUniform, sceneDelegate->GetPrimvarDescriptors(id, HdInterpolationUniform) },
+        };
+    }
+
+    void GetObjectPrimvars(HdPrimvarDescriptorMap const& descriptor_map, HdSceneDelegate* sceneDelegate,
+                           const HdDirtyBits* dirtyBits)
+    {
+        assert(m_cyclesObject != nullptr);
+
+        const SdfPath& id = T::GetId();
+
+        // visibility
+        m_visibilityFlags = 0;
+        bool visCamera = true;
+        bool visDiffuse = true;
+        bool visGlossy = true;
+        bool visScatter = true;
+        bool visShadow = true;
+        bool visTransmission = true;
+
+        // motion blur
+        m_motionBlur = true;
+        m_motionTransformSteps = 3;
+        m_motionDeformSteps = 3;
+
+        // pass and names
+        m_cyclesObject->is_shadow_catcher = false;
+        m_cyclesObject->pass_id = 0;
+        m_cyclesObject->use_holdout = false;
+        m_cyclesObject->asset_name = "";
+        m_cyclesObject->lightgroup = "";
+
+        for (auto& descriptor_interpolation : descriptor_map) {
+            for (auto& pv : descriptor_interpolation.second) {
+                if (!HdChangeTracker::IsPrimvarDirty(*dirtyBits, id, pv.name)) {
+                    continue;
+                }
+
+                const std::string primvar_name = std::string { "primvars:" } + pv.name.GetString();
+
+                // visibility
+                if (primvar_name == usdCyclesTokens->primvarsCyclesObjectVisibilityCamera) {
+                    VtValue value = T::GetPrimvar(sceneDelegate, pv.name);
+                    visCamera = value.Get<bool>();
+                    continue;
+                }
+
+                if (primvar_name == usdCyclesTokens->primvarsCyclesObjectVisibilityDiffuse) {
+                    VtValue value = T::GetPrimvar(sceneDelegate, pv.name);
+                    visDiffuse = value.Get<bool>();
+                    continue;
+                }
+
+                if (primvar_name == usdCyclesTokens->primvarsCyclesObjectVisibilityGlossy) {
+                    VtValue value = T::GetPrimvar(sceneDelegate, pv.name);
+                    visGlossy = value.Get<bool>();
+                    continue;
+                }
+
+                if (primvar_name == usdCyclesTokens->primvarsCyclesObjectVisibilityScatter) {
+                    VtValue value = T::GetPrimvar(sceneDelegate, pv.name);
+                    visScatter = value.Get<bool>();
+                    continue;
+                }
+
+                if (primvar_name == usdCyclesTokens->primvarsCyclesObjectVisibilityShadow) {
+                    VtValue value = T::GetPrimvar(sceneDelegate, pv.name);
+                    visShadow = value.Get<bool>();
+                    continue;
+                }
+
+                if (primvar_name == usdCyclesTokens->primvarsCyclesObjectVisibilityTransmission) {
+                    VtValue value = T::GetPrimvar(sceneDelegate, pv.name);
+                    visTransmission = value.Get<bool>();
+                    continue;
+                }
+
+                // motion blur
+                if (primvar_name == usdCyclesTokens->primvarsCyclesObjectMblur) {
+                    VtValue value = T::GetPrimvar(sceneDelegate, pv.name);
+                    m_motionBlur = value.Get<bool>();
+                    continue;
+                }
+
+                if (primvar_name == usdCyclesTokens->primvarsCyclesObjectTransformSamples) {
+                    VtValue value = T::GetPrimvar(sceneDelegate, pv.name);
+                    m_motionTransformSteps = value.Get<int>();
+                    continue;
+                }
+
+                if (primvar_name == usdCyclesTokens->primvarsCyclesObjectDeformSamples) {
+                    VtValue value = T::GetPrimvar(sceneDelegate, pv.name);
+                    m_motionDeformSteps = value.Get<int>();
+                    continue;
+                }
+
+                // names
+                if (primvar_name == usdCyclesTokens->primvarsCyclesObjectAsset_name) {
+                    VtValue value = T::GetPrimvar(sceneDelegate, pv.name);
+                    auto& assetName = value.Get<std::string>();
+                    m_cyclesObject->asset_name = ccl::ustring(assetName);
+                    continue;
+                }
+
+                if (primvar_name == usdCyclesTokens->primvarsCyclesObjectLightgroup) {
+                    VtValue value = T::GetPrimvar(sceneDelegate, pv.name);
+                    auto& lightGroup = value.Get<std::string>();
+                    m_cyclesObject->lightgroup = ccl::ustring(lightGroup);
+                    continue;
+                }
+
+                // pass
+                if (primvar_name == usdCyclesTokens->primvarsCyclesObjectPass_id) {
+                    VtValue value = T::GetPrimvar(sceneDelegate, pv.name);
+                    m_cyclesObject->pass_id = value.Get<int>();
+                    continue;
+                }
+
+                // shadows
+                if (primvar_name == usdCyclesTokens->primvarsCyclesObjectIs_shadow_catcher) {
+                    VtValue value = T::GetPrimvar(sceneDelegate, pv.name);
+                    m_cyclesObject->is_shadow_catcher = value.Get<bool>();
+                    continue;
+                }
+
+                if (primvar_name == usdCyclesTokens->primvarsCyclesObjectUse_holdout) {
+                    VtValue value = T::GetPrimvar(sceneDelegate, pv.name);
+                    m_cyclesObject->use_holdout = value.Get<bool>();
+                    continue;
+                }
+            }
+        }
+
+        // build visibility flags
+        m_visibilityFlags |= visCamera ? ccl::PATH_RAY_CAMERA : 0;
+        m_visibilityFlags |= visDiffuse ? ccl::PATH_RAY_DIFFUSE : 0;
+        m_visibilityFlags |= visGlossy ? ccl::PATH_RAY_GLOSSY : 0;
+        m_visibilityFlags |= visScatter ? ccl::PATH_RAY_VOLUME_SCATTER : 0;
+        m_visibilityFlags |= visShadow ? ccl::PATH_RAY_SHADOW : 0;
+        m_visibilityFlags |= visTransmission ? ccl::PATH_RAY_TRANSMIT : 0;
+    }
+
+    ccl::Object* m_cyclesObject;
+
+    unsigned int m_visibilityFlags;
+
+    bool m_motionBlur;
+    int m_motionTransformSteps;
+    int m_motionDeformSteps;
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif  //HDBLACKBIRD_RPRIM_H

--- a/plugin/hdCycles/volume.cpp
+++ b/plugin/hdCycles/volume.cpp
@@ -60,8 +60,7 @@ TF_DEFINE_PRIVATE_TOKENS(_tokens,
 // clang-format on
 
 HdCyclesVolume::HdCyclesVolume(SdfPath const& id, SdfPath const& instancerId, HdCyclesRenderDelegate* a_renderDelegate)
-    : HdVolume(id, instancerId)
-    , m_cyclesObject(nullptr)
+    : HdBbRPrim<HdVolume>(id, instancerId)
     , m_cyclesVolume(nullptr)
     , m_renderDelegate(a_renderDelegate)
 {
@@ -264,7 +263,7 @@ HdCyclesVolume::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam,
 
     ccl::Scene* scene = param->GetCyclesScene();
 
-    HdCyclesPDPIMap pdpi;
+    HdPrimvarDescriptorMap primvar_descriptor_map;
     bool update_volumes = false;
 
     ccl::vector<int> old_voxel_slots = get_voxel_image_slots(m_cyclesVolume);
@@ -302,7 +301,8 @@ HdCyclesVolume::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam,
     }
 
     if (*dirtyBits & HdChangeTracker::DirtyPrimvar) {
-        HdCyclesPopulatePrimvarDescsPerInterpolation(sceneDelegate, id, &pdpi);
+        primvar_descriptor_map = GetPrimvarDescriptorMap(sceneDelegate);
+        GetObjectPrimvars(primvar_descriptor_map, sceneDelegate, dirtyBits);
     }
 
     if (*dirtyBits & HdChangeTracker::DirtyMaterialId) {
@@ -323,73 +323,17 @@ HdCyclesVolume::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam,
         }
     }
 
-    for (auto& primvarDescsEntry : pdpi) {
+    for (auto& primvarDescsEntry : primvar_descriptor_map) {
         for (auto& pv : primvarDescsEntry.second) {
 
             if (!HdChangeTracker::IsPrimvarDirty(*dirtyBits, id, pv.name)) {
                 continue;
             }
 
-            // Object Generic
-
-            m_useMotionBlur = _HdCyclesGetVolumeParam<bool>(pv, dirtyBits, id, this, sceneDelegate,
-                                                            usdCyclesTokens->primvarsCyclesObjectMblur,
-                                                            m_useMotionBlur);
-
             m_cyclesObject->velocity_scale
                 = _HdCyclesGetVolumeParam<float>(pv, dirtyBits, id, this, sceneDelegate,
                                                  usdCyclesTokens->primvarsCyclesObjectMblurVolume_vel_scale,
                                                  m_cyclesObject->velocity_scale);
-
-            m_cyclesObject->pass_id = _HdCyclesGetVolumeParam<bool>(pv, dirtyBits, id, this, sceneDelegate,
-                                                                    usdCyclesTokens->primvarsCyclesObjectPass_id,
-                                                                    m_cyclesObject->pass_id);
-
-            m_cyclesObject->use_holdout = _HdCyclesGetVolumeParam<bool>(pv, dirtyBits, id, this, sceneDelegate,
-                                                                        usdCyclesTokens->primvarsCyclesObjectUse_holdout,
-                                                                        m_cyclesObject->use_holdout);
-
-            std::string lightGroup = m_cyclesObject->lightgroup.c_str();
-            lightGroup = _HdCyclesGetVolumeParam<std::string>(pv, dirtyBits, id, this, sceneDelegate,
-                                                              usdCyclesTokens->primvarsCyclesObjectLightgroup,
-                                                              lightGroup);
-            m_cyclesObject->lightgroup = ccl::ustring(lightGroup);
-
-            // Visibility
-
-            m_visibilityFlags = 0;
-
-            m_visCamera = _HdCyclesGetVolumeParam<bool>(pv, dirtyBits, id, this, sceneDelegate,
-                                                        usdCyclesTokens->primvarsCyclesObjectVisibilityCamera,
-                                                        m_visCamera);
-
-            m_visDiffuse = _HdCyclesGetVolumeParam<bool>(pv, dirtyBits, id, this, sceneDelegate,
-                                                         usdCyclesTokens->primvarsCyclesObjectVisibilityDiffuse,
-                                                         m_visDiffuse);
-
-            m_visGlossy = _HdCyclesGetVolumeParam<bool>(pv, dirtyBits, id, this, sceneDelegate,
-                                                        usdCyclesTokens->primvarsCyclesObjectVisibilityGlossy,
-                                                        m_visGlossy);
-
-            m_visScatter = _HdCyclesGetVolumeParam<bool>(pv, dirtyBits, id, this, sceneDelegate,
-                                                         usdCyclesTokens->primvarsCyclesObjectVisibilityScatter,
-                                                         m_visScatter);
-
-            m_visShadow = _HdCyclesGetVolumeParam<bool>(pv, dirtyBits, id, this, sceneDelegate,
-                                                        usdCyclesTokens->primvarsCyclesObjectVisibilityShadow,
-                                                        m_visShadow);
-
-            m_visTransmission
-                = _HdCyclesGetVolumeParam<bool>(pv, dirtyBits, id, this, sceneDelegate,
-                                                usdCyclesTokens->primvarsCyclesObjectVisibilityTransmission,
-                                                m_visTransmission);
-
-            m_visibilityFlags |= m_visCamera ? ccl::PATH_RAY_CAMERA : 0;
-            m_visibilityFlags |= m_visDiffuse ? ccl::PATH_RAY_DIFFUSE : 0;
-            m_visibilityFlags |= m_visGlossy ? ccl::PATH_RAY_GLOSSY : 0;
-            m_visibilityFlags |= m_visScatter ? ccl::PATH_RAY_VOLUME_SCATTER : 0;
-            m_visibilityFlags |= m_visShadow ? ccl::PATH_RAY_SHADOW : 0;
-            m_visibilityFlags |= m_visTransmission ? ccl::PATH_RAY_TRANSMIT : 0;
 
             update_volumes = true;
         }

--- a/plugin/hdCycles/volume.h
+++ b/plugin/hdCycles/volume.h
@@ -25,6 +25,7 @@
 #include "hdcycles.h"
 #include "renderDelegate.h"
 #include "utils.h"
+#include "rprim.h"
 
 #include <util/util_transform.h>
 
@@ -52,7 +53,7 @@ class HdCyclesRenderDelegate;
  * @brief USD Volume mapped to Cycles Volume
  * 
  */
-class HdCyclesVolume final : public HdVolume {
+class HdCyclesVolume final : public HdBbRPrim<HdVolume> {
 public:
     /**
      * @brief Construct a new HdCycles Volume object
@@ -152,20 +153,9 @@ private:
      */
     void _UpdateObject(ccl::Scene* scene, HdCyclesRenderParam* param, HdDirtyBits* dirtyBits, bool rebuildBvh);
 
-    ccl::Object* m_cyclesObject;
-
     ccl::Mesh* m_cyclesVolume;
 
     std::vector<ccl::Object*> m_cyclesInstances;
-
-    unsigned int m_visibilityFlags;
-
-    bool m_visCamera;
-    bool m_visDiffuse;
-    bool m_visGlossy;
-    bool m_visScatter;
-    bool m_visShadow;
-    bool m_visTransmission;
 
     HdCyclesRenderDelegate* m_renderDelegate;
 


### PR DESCRIPTION
Remove code duplication and slide new `HdBbRPrim` class under mesh, points and curves. `HdBbRPrim` carries helper methods to manage object properties.