### PR TITLE
Assign visibility flags from prototype to instances

### DIFF
--- a/plugin/hdCycles/mesh.cpp
+++ b/plugin/hdCycles/mesh.cpp
@@ -1345,10 +1345,10 @@ HdCyclesMesh::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam, H
                 if (reallocate_array) {
                     m_renderDelegate->GetCyclesRenderParam()->AddObjectArray(m_cyclesInstances);
                 }
-
-                // remove prototype from list of objects to render
-                m_renderDelegate->GetCyclesRenderParam()->RemoveObject(m_cyclesObject);
             }
+
+            // remove prototype from list of objects to render
+            m_renderDelegate->GetCyclesRenderParam()->RemoveObject(m_cyclesObject);
         }
     }
 

--- a/plugin/hdCycles/mesh.cpp
+++ b/plugin/hdCycles/mesh.cpp
@@ -1343,20 +1343,17 @@ HdCyclesMesh::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam, H
                 if (reallocate_array) {
                     m_renderDelegate->GetCyclesRenderParam()->AddObjectArray(m_cyclesInstances);
                 }
+
+                // remove prototype from list of objects to render
+                m_renderDelegate->GetCyclesRenderParam()->RemoveObject(m_cyclesObject);
             }
         }
     }
 
-    // instancing: steal visibility flags from the prototype and hide the prototype
+    // update instances: steal visibility flags from the prototype
     if (*dirtyBits & HdChangeTracker::DirtyPrimvar) {
-        // get visibility flags from the prototype
         for(ccl::Object& object : m_cyclesInstances) {
             object.visibility = m_visibilityFlags;
-        }
-
-        // hide prototype
-        if(!m_cyclesInstances.empty()) {
-            m_visibilityFlags = 0;
         }
     }
 

--- a/plugin/hdCycles/mesh.cpp
+++ b/plugin/hdCycles/mesh.cpp
@@ -1179,6 +1179,8 @@ HdCyclesMesh::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam, H
     // -------------------------------------
     // -- Resolve Drawstyles
 
+    m_refineLevel = 0;
+
     if (*dirtyBits & HdChangeTracker::DirtyVisibility) {
         _sharedData.visible = sceneDelegate->GetVisible(id);
         _UpdateObject(scene, param, dirtyBits, false);

--- a/plugin/hdCycles/mesh.cpp
+++ b/plugin/hdCycles/mesh.cpp
@@ -1347,6 +1347,7 @@ HdCyclesMesh::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam, H
         }
     }
 
+    // instancing: steal visibility flags from the prototype and hide the prototype
     if (*dirtyBits & HdChangeTracker::DirtyPrimvar) {
         // get visibility flags from the prototype
         for(ccl::Object& object : m_cyclesInstances) {
@@ -1354,7 +1355,9 @@ HdCyclesMesh::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam, H
         }
 
         // hide prototype
-        m_visibilityFlags = 0;
+        if(!m_cyclesInstances.empty()) {
+            m_visibilityFlags = 0;
+        }
     }
 
     _FinishMesh(scene);


### PR DESCRIPTION
Fixes:
* excessive memory allocation(caused by uninitialized refine level)
* prototypes are removed from the scene every time instancer is marked dirty.