### PR TITLE
Point light fix + cylinder light disable

### DIFF
--- a/plugin/hdCycles/light.cpp
+++ b/plugin/hdCycles/light.cpp
@@ -437,6 +437,7 @@ HdCyclesLight::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam, 
         if (m_hdLightType == HdPrimTypeTokens->cylinderLight) {
             // TODO: Implement
             // Cycles has no concept of cylinder lights.
+            intensity = 0.0f;
         }
 
         if (m_hdLightType == HdPrimTypeTokens->sphereLight) {
@@ -444,7 +445,14 @@ HdCyclesLight::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam, 
             if (radius.IsHolding<float>())
                 m_cyclesLight->size = radius.UncheckedGet<float>();
 
-            exposureOffset = 1.0f;
+            VtValue treatAsPoint = sceneDelegate->GetLightParamValue(id, UsdLuxTokens->treatAsPoint);
+            if (treatAsPoint.IsHolding<bool>() && treatAsPoint.UncheckedGet<bool>()) {
+                m_cyclesLight->size = 0.0f;
+                normalize = true;
+                exposureOffset = 3.0f;
+            }
+
+            exposureOffset += 1.0f;
 
             if (!normalize) {
                 size = m_cyclesLight->size * m_cyclesLight->size * 4.0f * M_PI_F;
@@ -462,14 +470,9 @@ HdCyclesLight::Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam, 
                 m_cyclesLight->spot_smooth = shapingConeSoftness.UncheckedGet<float>();
                 m_cyclesLight->type = ccl::LIGHT_SPOT;
             }
-
-            if (m_cyclesLight->type == ccl::LIGHT_SPOT) {
-                exposureOffset += 1.0f;
-            }
         }
 
         if (m_hdLightType == HdPrimTypeTokens->distantLight) {
-            // TODO: Test this
             VtValue angle = sceneDelegate->GetLightParamValue(id, HdLightTokens->angle);
             if (angle.IsHolding<float>()) {
                 m_cyclesLight->angle = angle.UncheckedGet<float>() * (M_PI_F / 180.0f);


### PR DESCRIPTION
Some light fixes, make sure size is 0.0f when a point light is specified (no radius schema, so it needs to be set to 0.0f). Cylinder light intensity set to 0.0f to indicate that they are not supported (yet). Addresses FD #8973