### PR TITLE
Sourcing constant primvars in volumes

### DIFF
--- a/plugin/hdCycles/volume.h
+++ b/plugin/hdCycles/volume.h
@@ -24,8 +24,8 @@
 
 #include "hdcycles.h"
 #include "renderDelegate.h"
-#include "utils.h"
 #include "rprim.h"
+#include "utils.h"
 
 #include <util/util_transform.h>
 
@@ -142,6 +142,8 @@ private:
      * @brief Populate the Cycles mesh representation from delegate's data
      */
     void _PopulateVolume(const SdfPath& id, HdSceneDelegate* delegate, ccl::Scene* scene);
+    void _PopulateConstantPrimvars(const SdfPath& id, HdSceneDelegate* delegate, ccl::Scene* scene,
+                                   HdPrimvarDescriptorMap const& descriptor_map, HdDirtyBits* dirtyBits);
 
     /**
      * @brief Update the OpenVDB loader grid for mesh builder  
@@ -154,6 +156,8 @@ private:
     void _UpdateObject(ccl::Scene* scene, HdCyclesRenderParam* param, HdDirtyBits* dirtyBits, bool rebuildBvh);
 
     ccl::Mesh* m_cyclesVolume;
+
+    HdCyclesObjectSourceSharedPtr m_object_source;
 
     std::vector<ccl::Object*> m_cyclesInstances;
 


### PR DESCRIPTION
**Description**
The volume synchronization code does not read primvars besides common object setting. This code reads constant primvars into the geometry attributes.

For the primvars to be used in attribute nodes and then plugged to volume shaders, you need [this core patch](https://github.com/tangent-opensource/coreBlackbird/pull/96).

FD-8574

**Changes**
- Added object attribute source for constant primvars in the volume primitive

**Test**
Here is a test file with "customColor" and "customDensity" connected to a principled volume node
[test-volume-constant-primvars.zip](https://github.com/tangent-opensource/hdBlackbird/files/6864364/test-volume-constant-primvars.zip)
