### PR TITLE
Default to computing tangents using mikktspace

### DIFF
--- a/plugin/hdCycles/mesh.cpp
+++ b/plugin/hdCycles/mesh.cpp
@@ -222,7 +222,7 @@ HdCyclesMesh::_PopulateTangents(HdSceneDelegate* sceneDelegate, const SdfPath& i
 
                 for (size_t i = 0; i < m_cyclesMesh->triangles.size(); ++i) {
                     auto vertex_index = m_cyclesMesh->triangles[i];
-                    tangent_data[i] = ccl::normalize(m_limit_vs[vertex_index]);
+                    tangent_data[i] = ccl::normalize(m_limit_us[vertex_index]);
                 }
             }
 

--- a/plugin/hdCycles/mesh.cpp
+++ b/plugin/hdCycles/mesh.cpp
@@ -213,11 +213,9 @@ HdCyclesMesh::_PopulateTangents(HdSceneDelegate* sceneDelegate, const SdfPath& i
             continue;
         }
 
-        if (need_tangent) {
-            // Forced for now
-            bool need_sign = true;
-            mikk_compute_tangents(name.c_str(), m_cyclesMesh, need_sign, true);
-        }
+        // Forced for now
+        bool need_sign = true;
+        mikk_compute_tangents(name.c_str(), m_cyclesMesh, need_sign, true);
     }
 }
 

--- a/plugin/hdCycles/mesh.cpp
+++ b/plugin/hdCycles/mesh.cpp
@@ -213,34 +213,6 @@ HdCyclesMesh::_PopulateTangents(HdSceneDelegate* sceneDelegate, const SdfPath& i
             continue;
         }
 
-        // Take tangent from subdivision limit surface
-        if (refiner->IsSubdivided()) {
-            // subdivided tangents are per vertex
-
-            if (m_cyclesMesh->need_attribute(scene, ccl::ATTR_STD_UV_TANGENT)) {
-                ccl::Attribute* tangent_attrib = attributes->add(ccl::ATTR_STD_UV_TANGENT, tangent_name);
-                ccl::float3* tangent_data = tangent_attrib->data_float3();
-
-                for (size_t i = 0; i < m_cyclesMesh->triangles.size(); ++i) {
-                    auto vertex_index = m_cyclesMesh->triangles[i];
-                    tangent_data[i] = m_limit_us[vertex_index];
-                }
-            }
-
-            if (m_cyclesMesh->need_attribute(scene, ccl::ATTR_STD_UV_TANGENT_SIGN)) {
-                auto sign_attrib = attributes->add(ccl::ATTR_STD_UV_TANGENT_SIGN, sign_name);
-                auto sign_data = sign_attrib->data_float();
-
-                for (size_t i = 0; i < m_cyclesMesh->triangles.size(); ++i) {
-                    sign_data[i] = 1.0f;
-                }
-            }
-
-            continue;
-        }
-
-        // Forced true for now... Should be based on shader compilation needs
-        need_tangent = true;
         if (need_tangent) {
             // Forced for now
             bool need_sign = true;

--- a/plugin/hdCycles/mesh.h
+++ b/plugin/hdCycles/mesh.h
@@ -250,6 +250,7 @@ private:
 
     int m_refineLevel;
     std::shared_ptr<HdBbMeshTopology> m_topology;
+    bool m_useLimitSurfaceTangents;
 
     float m_velocityScale;
 

--- a/plugin/usdCycles/schema.usda
+++ b/plugin/usdCycles/schema.usda
@@ -1418,7 +1418,7 @@ class "CyclesMeshSettingsAPI" (
         doc = "Stop subdividing when this level is reached even if the dice rate would produce finer tessellation"
     )
 
-    uniform bool primvars:cycles:mesh:subdivision_use_limit_tangents = 3 (
+    uniform bool primvars:cycles:mesh:subdivision_use_limit_tangents = false (
         customData = {
             string apiName = "mesh_subdivision_use_limit_tangents"
         }

--- a/plugin/usdCycles/schema.usda
+++ b/plugin/usdCycles/schema.usda
@@ -1417,6 +1417,15 @@ class "CyclesMeshSettingsAPI" (
         displayName = "Max Subdivisions"
         doc = "Stop subdividing when this level is reached even if the dice rate would produce finer tessellation"
     )
+
+    uniform bool primvars:cycles:mesh:subdivision_use_limit_tangents = 3 (
+        customData = {
+            string apiName = "mesh_subdivision_use_limit_tangents"
+        }
+        displayGroup = "Subdivision"
+        displayName = "Use tangents calculated from the limit surface derivatives"
+        doc = "Use the Opensubdiv tangent space. Toggle this only if you know that normal maps have been authored on the limit surface."
+    )
 }
 
 class "CyclesMaterialSettingsAPI" (


### PR DESCRIPTION
By default compute tangents using Mikktspace to match export workflow, but allow usage of limit surface tangents through a new setting. 

FD-9026