### PR TITLE
Better reading of Blender color spaces

### DIFF
--- a/plugin/hdCycles/material.cpp
+++ b/plugin/hdCycles/material.cpp
@@ -484,6 +484,15 @@ convertCyclesNode(HdMaterialNode& usd_node, ccl::ShaderGraph* cycles_shader_grap
     if (cycles_node_name == "image_texture") {
         ccl::ImageTextureNode* tex = static_cast<ccl::ImageTextureNode*>(cyclesNode);
 
+        // Tangent Animation specific fix - Blender->USD inserts underscores in those color spaces.
+        if (tex->colorspace == "Filmic_sRGB") {
+            tex->colorspace = ccl::ustring("Filmic sRGB");
+        } else if (tex->colorspace == "Filmic_Log") {
+            tex->colorspace = ccl::ustring("Filmic Log");
+        } else if (tex->colorspace == "Linear ACES") {
+            tex->colorspace = ccl::ustring("Linear ACES");
+        }
+
         // Handle udim tiles
         if (HdCyclesPathIsUDIM(tex->filename.string())) {
             HdCyclesParseUDIMS(tex->filename.string(), tex->tiles);

--- a/plugin/hdCycles/material.cpp
+++ b/plugin/hdCycles/material.cpp
@@ -489,7 +489,7 @@ convertCyclesNode(HdMaterialNode& usd_node, ccl::ShaderGraph* cycles_shader_grap
             tex->colorspace = ccl::ustring("Filmic sRGB");
         } else if (tex->colorspace == "Filmic_Log") {
             tex->colorspace = ccl::ustring("Filmic Log");
-        } else if (tex->colorspace == "Linear ACES") {
+        } else if (tex->colorspace == "Linear_ACES") {
             tex->colorspace = ccl::ustring("Linear ACES");
         }
 


### PR DESCRIPTION
Blender->USD appears to write the "Filmic sRGB" space as "Filmic_sRGB".
Added special cases to change those color spaces back to our names.